### PR TITLE
Improved: Create Facility service to include update of facility data and handling of ownerPartyId, latitude and longitude

### DIFF
--- a/service/co/hotwax/oms/FacilityServices.xml
+++ b/service/co/hotwax/oms/FacilityServices.xml
@@ -2,10 +2,9 @@
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-2.1.xsd">
 
     <!-- Create Facility -->
-    <service verb="create" noun="Facility">
+    <service verb="store" noun="Facility">
         <description>
-            Allows a fulfillment location to be created with basic location data.
-            Also creates the primary address for the location if provided in the request.
+            Store (create/update) the fulfillment location with basic location and address data.
         </description>
         <in-parameters>
             <parameter name="locationId" required="true">
@@ -39,6 +38,12 @@
             <parameter name="postalCode">
                 <description>The postal code for the address.</description>
             </parameter>
+            <parameter name="latitude" type="BigDecimal">
+                <description>The geographic coordinate representing the latitude for the address.</description>
+            </parameter>
+            <parameter name="longitude" type="BigDecimal">
+                <description>The geographic coordinate representing the longitude for the address.</description>
+            </parameter>
         </in-parameters>
         <out-parameters>
             <parameter name="locationId">
@@ -49,15 +54,43 @@
             </parameter>
         </out-parameters>
         <actions>
-            <!-- Using OOTB create#Facility -->
-            <service-call name="mantle.facility.FacilityServices.create#Facility" out-map="context"
-                    in-map="context + [pseudoId:locationId, facilityName:locationName,
-                    facilityTypeEnumId:locationType]"/>
+            <!-- If no ownerPartyId value incoming, set from the default product store -->
+            <if condition="!ownerPartyId">
+                <!-- get ProductStore ID from ProductStoreSetting of hostname-->
+                <service-call name="co.hotwax.oms.StoreServices.get#ProductStoreIdFromHostName"
+                        in-map="[requestHostName:ec.web?.getHostName(false) ?: 'localhost']" out-map="productStoreIdContext"/>
+                <set field="defaultProductStoreId" from="productStoreIdContext?.productStoreId"/>
 
-            <!-- Creating default pick location for the facility -->
-            <service-call name="mantle.facility.FacilityServices.create#FacilityLocation" out-map="context"
-                    in-map="[facilityId:facilityId, locationSeqId:'DEFAULT_PICK_LOC',
-                    locationTypeEnumId:'FltPick']"/>
+                <entity-find-one entity-name="mantle.product.store.ProductStore" value-field="defaultProductStore">
+                    <field-map field-name="productStoreId" from="defaultProductStoreId"/>
+                </entity-find-one>
+                <set field="ownerPartyId" from="defaultProductStore?.organizationPartyId"/>
+            </if>
+
+            <!-- Create/Update Facility -->
+            <!-- Check if facility existing for the locationId -->
+            <entity-find entity-name="mantle.facility.Facility" list="facilityList">
+                <econdition field-name="pseudoId" from="locationId"/>
+            </entity-find>
+
+            <if condition="facilityList"><then>
+                <set field="facilityId" from="facilityList.first?.facilityId"/>
+                <!-- Using OOTB update#Facility -->
+                <service-call name="mantle.facility.FacilityServices.update#Facility" out-map="context"
+                        in-map='context + [facilityId:facilityId, facilityName:locationName,
+                        facilityTypeEnumId:locationType]'/>
+            </then><else>
+                <!-- Using OOTB create#Facility -->
+                <service-call name="mantle.facility.FacilityServices.create#Facility" out-map="context"
+                        in-map='context + [pseudoId:locationId, facilityName:locationName,
+                        facilityTypeEnumId:locationType]'/>
+
+                <!-- Creating default pick location when new facility created -->
+                <service-call name="mantle.facility.FacilityServices.create#FacilityLocation" out-map="context"
+                        in-map="[facilityId:facilityId, locationSeqId:'DEFAULT_PICK_LOC',
+                        locationTypeEnumId:'FltPick']"/>
+            </else>
+            </if>
         </actions>
     </service>
 

--- a/service/co/hotwax/oms/FacilityServices.xml
+++ b/service/co/hotwax/oms/FacilityServices.xml
@@ -23,7 +23,6 @@
             <parameter name="locationType" default-value="FcTpRetailStore">
                 <description>The type of the fulfillment location.</description>
             </parameter>
-            <!-- TODO discuss the use of ownerPartyId field -->
             <parameter name="ownerPartyId">
                 <description>The ID of the vendor organization for the fulfillment location.</description>
             </parameter>
@@ -64,19 +63,6 @@
             </parameter>
         </out-parameters>
         <actions>
-            <!-- If no ownerPartyId value incoming, set from the default product store -->
-            <if condition="!ownerPartyId">
-                <!-- get ProductStore ID from ProductStoreSetting of hostname-->
-                <service-call name="co.hotwax.oms.StoreServices.get#ProductStoreIdFromHostName"
-                        in-map="[requestHostName:ec.web?.getHostName(false) ?: 'localhost']" out-map="productStoreIdContext"/>
-                <set field="defaultProductStoreId" from="productStoreIdContext?.productStoreId"/>
-
-                <entity-find-one entity-name="mantle.product.store.ProductStore" value-field="defaultProductStore">
-                    <field-map field-name="productStoreId" from="defaultProductStoreId"/>
-                </entity-find-one>
-                <set field="ownerPartyId" from="defaultProductStore?.organizationPartyId"/>
-            </if>
-
             <!-- Create/Update Facility -->
             <!-- Check if facility existing -->
             <entity-find entity-name="mantle.facility.Facility" list="facilityList">
@@ -86,21 +72,20 @@
             <if condition="!facilityList.isEmpty()"><then>
                 <set field="facilityId" from="facilityList.first?.facilityId"/>
                 <!-- Using OOTB update#Facility -->
-                <service-call name="mantle.facility.FacilityServices.update#Facility" out-map="context"
+                <service-call name="mantle.facility.FacilityServices.update#Facility" out-map="facilityOut"
                         in-map='context + [pseudoId:locationId, facilityId:facilityId,
                         facilityName:locationName, facilityTypeEnumId:locationType]'/>
             </then><else>
                 <!-- Using OOTB create#Facility -->
-                <service-call name="mantle.facility.FacilityServices.create#Facility" out-map="context"
+                <service-call name="mantle.facility.FacilityServices.create#Facility" out-map="facilityOut"
                         in-map='context + [pseudoId:locationId, facilityName:locationName,
                         facilityTypeEnumId:locationType]'/>
 
                 <!-- Creating default pick location when new facility created -->
                 <service-call name="mantle.facility.FacilityServices.create#FacilityLocation" out-map="context"
-                        in-map="[facilityId:facilityId, locationSeqId:'DEFAULT_PICK_LOC',
+                        in-map="[facilityId:facilityOut?.facilityId, locationSeqId:'DEFAULT_PICK_LOC',
                         locationTypeEnumId:'FltPick']"/>
-                <set field="facilityId" from="context.facilityId"/>
-                <set field="locationId" from="context.facilityId"/>
+                <set field="facilityId" from="facilityOut.facilityId"/>
             </else>
             </if>
         </actions>

--- a/service/co/hotwax/oms/FacilityServices.xml
+++ b/service/co/hotwax/oms/FacilityServices.xml
@@ -44,6 +44,9 @@
             <parameter name="longitude" type="BigDecimal">
                 <description>The geographic coordinate representing the longitude for the address.</description>
             </parameter>
+            <parameter name="contactNumber">
+                <description>The contact number for the fulfillment location.</description>
+            </parameter>
         </in-parameters>
         <out-parameters>
             <parameter name="locationId">

--- a/service/co/hotwax/oms/FacilityServices.xml
+++ b/service/co/hotwax/oms/FacilityServices.xml
@@ -5,10 +5,17 @@
     <service verb="store" noun="Facility">
         <description>
             Store (create/update) the fulfillment location with basic location and address data.
+            The service will update the facility based on the provided facilityId, else will create
+            the new fulfillment location.
         </description>
         <in-parameters>
-            <parameter name="locationId" required="true">
-                <description>The unique ID of the fulfillment location in the external system.</description>
+            <parameter name="facilityId">
+                <description>The unique ID of the fulfillment location in OMS. If not provided in the
+                    request, the system will auto generate the unqiue facilityId.</description>
+            </parameter>
+            <parameter name="locationId">
+                <description>The unique ID of the fulfillment location in the external system. If not
+                    provided in the request, this will be set as facilityId in the system.</description>
             </parameter>
             <parameter name="locationName" required="true">
                 <description>The name of the fulfillment location.</description>
@@ -30,10 +37,10 @@
                 <description>The city where the address is located in.</description>
             </parameter>
             <parameter name="stateProvinceGeoId">
-                <description>The state code where the address is located in.</description>
+                <description>The ID of the state code where the address is located in.</description>
             </parameter>
             <parameter name="countryGeoId">
-                <description>The country code for the address.</description>
+                <description>The ID of the country code for the address.</description>
             </parameter>
             <parameter name="postalCode">
                 <description>The postal code for the address.</description>
@@ -49,11 +56,11 @@
             </parameter>
         </in-parameters>
         <out-parameters>
+            <parameter name="facilityId">
+                <description>The unique ID of the fulfillment location in OMS.</description>
+            </parameter>
             <parameter name="locationId">
                 <description>The unique ID of the fulfillment location in the external system.</description>
-            </parameter>
-            <parameter name="facilityId">
-                <description>The unique ID generated for the fulfillment location in the internal system.</description>
             </parameter>
         </out-parameters>
         <actions>
@@ -71,17 +78,17 @@
             </if>
 
             <!-- Create/Update Facility -->
-            <!-- Check if facility existing for the locationId -->
+            <!-- Check if facility existing -->
             <entity-find entity-name="mantle.facility.Facility" list="facilityList">
-                <econdition field-name="pseudoId" from="locationId"/>
+                <econdition field-name="facilityId"/>
             </entity-find>
 
-            <if condition="facilityList"><then>
+            <if condition="!facilityList.isEmpty()"><then>
                 <set field="facilityId" from="facilityList.first?.facilityId"/>
                 <!-- Using OOTB update#Facility -->
                 <service-call name="mantle.facility.FacilityServices.update#Facility" out-map="context"
-                        in-map='context + [facilityId:facilityId, facilityName:locationName,
-                        facilityTypeEnumId:locationType]'/>
+                        in-map='context + [pseudoId:locationId, facilityId:facilityId,
+                        facilityName:locationName, facilityTypeEnumId:locationType]'/>
             </then><else>
                 <!-- Using OOTB create#Facility -->
                 <service-call name="mantle.facility.FacilityServices.create#Facility" out-map="context"
@@ -92,6 +99,8 @@
                 <service-call name="mantle.facility.FacilityServices.create#FacilityLocation" out-map="context"
                         in-map="[facilityId:facilityId, locationSeqId:'DEFAULT_PICK_LOC',
                         locationTypeEnumId:'FltPick']"/>
+                <set field="facilityId" from="context.facilityId"/>
+                <set field="locationId" from="context.facilityId"/>
             </else>
             </if>
         </actions>

--- a/service/oms.rest.xml
+++ b/service/oms.rest.xml
@@ -41,7 +41,7 @@
     </resource>
 
     <resource name="facilities">
-        <method type="post"><service name="co.hotwax.oms.FacilityServices.create#Facility"/></method>
+        <method type="post"><service name="co.hotwax.oms.FacilityServices.store#Facility"/></method>
         <method type="get"><service name="co.hotwax.oms.FacilityServices.find#Facilities"/></method>
 
         <id name="locationId">


### PR DESCRIPTION
Updated the service to create/update facility in OMS.

1. Updated create facility service to handle both create and update of facilities.
2. Added the handling of latitude and longitude parameters as these parameters were missing from the identified schema for the facility.

The basic facility details identified as part of facility schema:
  - locationId
  - locationName
  - locationType
  - ownerPartyId
  - address1
  - address2
  - city
  - stateProvinceGeoId
  - countryGeoId
  - postalCode
  - latitude
  - longitude
  - contactNumber