### PR TITLE
Implemented: Store Locator API to enable geo spatial queries to find facilities using Elastic Search

### DIFF
--- a/data/OmsDocumentData.xml
+++ b/data/OmsDocumentData.xml
@@ -13,10 +13,10 @@
         <fields fieldSeqId="06" fieldPath="contactMechs:postalAddress:address1"/>
         <fields fieldSeqId="07" fieldPath="contactMechs:postalAddress:city"/>
         <fields fieldSeqId="08" fieldPath="contactMechs:postalAddress:postalCode"/>
-        <fields fieldSeqId="09" fieldPath="contactMechs:postalAddress:stateProvinceGeoId" fieldNameAlias="stateCode"/>
+        <fields fieldSeqId="09" fieldPath="contactMechs:postalAddress:stateProvinceGeo:geoCodeAlpha2" fieldNameAlias="stateCode"/>
         <fields fieldSeqId="10" fieldPath="contactMechs:postalAddress:stateProvinceGeo:geoName" fieldNameAlias="state"/>
-        <fields fieldSeqId="11" fieldPath="contactMechs:contactMech:postalAddress:countyGeoId" fieldNameAlias="countryCode"/>
-        <fields fieldSeqId="12" fieldPath="contactMechs:contactMech:postalAddress:countyGeo:geoName" fieldNameAlias="country"/>
+        <fields fieldSeqId="11" fieldPath="contactMechs:contactMech:postalAddress:countryGeo:geoCodeAlpha3" fieldNameAlias="countryCode"/>
+        <fields fieldSeqId="12" fieldPath="contactMechs:contactMech:postalAddress:countryGeo:geoName" fieldNameAlias="country"/>
         <fields fieldSeqId="13" fieldPath="contactMechs:contactMech:telecomNumber:contactNumber" fieldNameAlias="storePhone"/>
         <fields fieldSeqId="14" fieldPath="contactMechs:contactMechPurposeId"/>
         <fields fieldSeqId="15" fieldPath="contactMechs:fromDate"/>

--- a/data/OmsDocumentData.xml
+++ b/data/OmsDocumentData.xml
@@ -2,12 +2,12 @@
 <entity-facade-xml type="seed-initial">
 
     <!-- ========== Store Document Data ========== -->
-    <dataDocuments dataDocumentId="OmsStore" indexName="store" documentName="Store"
+    <dataDocuments dataDocumentId="StoreDataDocument" indexName="store" documentName="Store"
             primaryEntityName="mantle.facility.Facility" documentTitle="${facilityId}">
         <fields fieldSeqId="01" fieldPath="facilityId"/>
         <fields fieldSeqId="02" fieldPath="pseudoId" fieldNameAlias="externalId"/>
         <fields fieldSeqId="03" fieldPath="facilityName" fieldNameAlias="storeName"/>
-        <fields fieldSeqId="04" fieldPath="facilityTypeEnumId" fieldNameAlias="storeType"/>
+        <fields fieldSeqId="04" fieldPath="type:enumCode" fieldNameAlias="storeType"/>
 
         <fields fieldSeqId="05" fieldPath="contactMechs:postalAddress:contactMechId"/>
         <fields fieldSeqId="06" fieldPath="contactMechs:postalAddress:address1"/>
@@ -29,6 +29,6 @@
     <!-- Search Data Feed for Stores -->
         <moqui.entity.feed.DataFeed dataFeedId="StoreSearch" dataFeedTypeEnumId="DTFDTP_RT_PUSH" indexOnStartEmpty="Y"
             feedName="Oms Search Store Data" feedReceiveServiceName="co.hotwax.oms.SearchServices.index#StoreDataDocuments">
-        <documents dataDocumentId="OmsStore"/>
+        <documents dataDocumentId="StoreDataDocument"/>
     </moqui.entity.feed.DataFeed>
 </entity-facade-xml>

--- a/data/OmsDocumentData.xml
+++ b/data/OmsDocumentData.xml
@@ -5,25 +5,25 @@
     <dataDocuments dataDocumentId="FacilityDataDocument" indexName="facility" documentName="Facility"
             primaryEntityName="mantle.facility.Facility" documentTitle="${facilityId}">
         <fields fieldSeqId="01" fieldPath="facilityId"/>
-        <fields fieldSeqId="02" fieldPath="pseudoId"/>
-        <fields fieldSeqId="03" fieldPath="facilityName"/>
-        <fields fieldSeqId="04" fieldPath="facilityTypeEnumId"/>
+        <fields fieldSeqId="02" fieldPath="pseudoId" fieldNameAlias="externalId"/>
+        <fields fieldSeqId="03" fieldPath="facilityName" fieldNameAlias="storeName"/>
+        <fields fieldSeqId="04" fieldPath="facilityTypeEnumId" fieldNameAlias="storeType"/>
 
         <fields fieldSeqId="05" fieldPath="contactMechs:postalAddress:contactMechId"/>
         <fields fieldSeqId="06" fieldPath="contactMechs:postalAddress:address1"/>
         <fields fieldSeqId="07" fieldPath="contactMechs:postalAddress:city"/>
         <fields fieldSeqId="08" fieldPath="contactMechs:postalAddress:postalCode"/>
-        <fields fieldSeqId="09" fieldPath="contactMechs:postalAddress:stateProvinceGeoId"/>
+        <fields fieldSeqId="09" fieldPath="contactMechs:postalAddress:stateProvinceGeoId" fieldNameAlias="stateCode"/>
         <fields fieldSeqId="10" fieldPath="contactMechs:postalAddress:stateProvinceGeo:geoName" fieldNameAlias="state"/>
-        <fields fieldSeqId="11" fieldPath="contactMechs:contactMech:postalAddress:countyGeoId"/>
+        <fields fieldSeqId="11" fieldPath="contactMechs:contactMech:postalAddress:countyGeoId" fieldNameAlias="countryCode"/>
         <fields fieldSeqId="12" fieldPath="contactMechs:contactMech:postalAddress:countyGeo:geoName" fieldNameAlias="country"/>
-        <fields fieldSeqId="13" fieldPath="contactMechs:contactMech:telecomNumber:contactNumber"/>
+        <fields fieldSeqId="13" fieldPath="contactMechs:contactMech:telecomNumber:contactNumber" fieldNameAlias="storePhone"/>
         <fields fieldSeqId="14" fieldPath="contactMechs:contactMechPurposeId"/>
         <fields fieldSeqId="15" fieldPath="contactMechs:fromDate"/>
         <fields fieldSeqId="16" fieldPath="contactMechs:thruDate"/>
 
-        <fields fieldSeqId="17" fieldPath="contactMechs:postalAddress:geoPoint:latitude" fieldNameAlias="latitude"/>
-        <fields fieldSeqId="18" fieldPath="contactMechs:postalAddress:geoPoint:longitude" fieldNameAlias="longitude"/>
+        <fields fieldSeqId="17" fieldPath="contactMechs:postalAddress:geoPoint:latitude"/>
+        <fields fieldSeqId="18" fieldPath="contactMechs:postalAddress:geoPoint:longitude"/>
     </dataDocuments>
 
     <!-- Search Data Feed for Facility -->

--- a/data/OmsDocumentData.xml
+++ b/data/OmsDocumentData.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="seed-initial">
+
+    <!-- ========== Facility Document Data ========== -->
+    <dataDocuments dataDocumentId="FacilityDataDocument" indexName="facility" documentName="Facility"
+            primaryEntityName="mantle.facility.Facility" documentTitle="${facilityId}">
+        <fields fieldSeqId="01" fieldPath="facilityId"/>
+        <fields fieldSeqId="02" fieldPath="pseudoId"/>
+        <fields fieldSeqId="03" fieldPath="facilityName"/>
+        <fields fieldSeqId="04" fieldPath="facilityTypeEnumId"/>
+
+        <fields fieldSeqId="05" fieldPath="contactMechs:postalAddress:contactMechId"/>
+        <fields fieldSeqId="06" fieldPath="contactMechs:postalAddress:address1"/>
+        <fields fieldSeqId="07" fieldPath="contactMechs:postalAddress:city"/>
+        <fields fieldSeqId="08" fieldPath="contactMechs:postalAddress:postalCode"/>
+        <fields fieldSeqId="09" fieldPath="contactMechs:postalAddress:stateProvinceGeoId"/>
+        <fields fieldSeqId="10" fieldPath="contactMechs:postalAddress:stateProvinceGeo:geoName" fieldNameAlias="state"/>
+        <fields fieldSeqId="11" fieldPath="contactMechs:contactMech:postalAddress:countyGeoId"/>
+        <fields fieldSeqId="12" fieldPath="contactMechs:contactMech:postalAddress:countyGeo:geoName" fieldNameAlias="country"/>
+        <fields fieldSeqId="13" fieldPath="contactMechs:contactMech:telecomNumber:contactNumber"/>
+        <fields fieldSeqId="14" fieldPath="contactMechs:contactMechPurposeId"/>
+        <fields fieldSeqId="15" fieldPath="contactMechs:fromDate"/>
+        <fields fieldSeqId="16" fieldPath="contactMechs:thruDate"/>
+
+        <fields fieldSeqId="17" fieldPath="contactMechs:postalAddress:geoPoint:latitude" fieldNameAlias="latitude"/>
+        <fields fieldSeqId="18" fieldPath="contactMechs:postalAddress:geoPoint:longitude" fieldNameAlias="longitude"/>
+    </dataDocuments>
+
+    <!-- Search Data Feed for Facility -->
+    <moqui.entity.feed.DataFeed dataFeedId="FacilitySearch" dataFeedTypeEnumId="DTFDTP_RT_PUSH" indexOnStartEmpty="Y"
+            feedName="Oms Search Facility Data" feedReceiveServiceName="co.hotwax.oms.SearchServices.index#FacilityDataDocuments">
+        <documents dataDocumentId="FacilityDataDocument"/>
+    </moqui.entity.feed.DataFeed>
+</entity-facade-xml>

--- a/data/OmsDocumentData.xml
+++ b/data/OmsDocumentData.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <entity-facade-xml type="seed-initial">
 
-    <!-- ========== Facility Document Data ========== -->
-    <dataDocuments dataDocumentId="FacilityDataDocument" indexName="facility" documentName="Facility"
+    <!-- ========== Store Document Data ========== -->
+    <dataDocuments dataDocumentId="OmsStore" indexName="store" documentName="Store"
             primaryEntityName="mantle.facility.Facility" documentTitle="${facilityId}">
         <fields fieldSeqId="01" fieldPath="facilityId"/>
         <fields fieldSeqId="02" fieldPath="pseudoId" fieldNameAlias="externalId"/>
@@ -26,9 +26,9 @@
         <fields fieldSeqId="18" fieldPath="contactMechs:postalAddress:geoPoint:longitude"/>
     </dataDocuments>
 
-    <!-- Search Data Feed for Facility -->
-    <moqui.entity.feed.DataFeed dataFeedId="FacilitySearch" dataFeedTypeEnumId="DTFDTP_RT_PUSH" indexOnStartEmpty="Y"
-            feedName="Oms Search Facility Data" feedReceiveServiceName="co.hotwax.oms.SearchServices.index#FacilityDataDocuments">
-        <documents dataDocumentId="FacilityDataDocument"/>
+    <!-- Search Data Feed for Stores -->
+        <moqui.entity.feed.DataFeed dataFeedId="StoreSearch" dataFeedTypeEnumId="DTFDTP_RT_PUSH" indexOnStartEmpty="Y"
+            feedName="Oms Search Store Data" feedReceiveServiceName="co.hotwax.oms.SearchServices.index#StoreDataDocuments">
+        <documents dataDocumentId="OmsStore"/>
     </moqui.entity.feed.DataFeed>
 </entity-facade-xml>

--- a/data/OrderAaaSetupData.xml
+++ b/data/OrderAaaSetupData.xml
@@ -12,4 +12,8 @@
     <!-- store setting used for dynamically setting the productStoreId depending on the hostname -->
     <moqui.basic.Enumeration enumCode="product_store_id_from_hostname" description="Product Store ID From Hostname" enumId="PsstHostname" enumTypeId="ProductStoreSettingType"/>
 
+    <!-- Adding enum codes for Store and Warehouse Facility Types -->
+    <moqui.basic.Enumeration description="Retail Store" enumCode="STORE" enumId="FcTpRetailStore" enumTypeId="FacilityType"/>
+    <moqui.basic.Enumeration description="Warehouse" enumCode="WAREHOUSE" enumId="FcTpWarehouse" enumTypeId="FacilityType"/>
+
 </entity-facade-xml>

--- a/esconfig/elastic.schema.store.json
+++ b/esconfig/elastic.schema.store.json
@@ -1,0 +1,43 @@
+{
+  "properties": {
+    "storeCode": {
+      "type": "keyword"
+    },
+    "storeName": {
+      "type": "text"
+    },
+    "storeType": {
+      "type": "text"
+    },
+    "address1": {
+      "type": "text"
+    },
+    "city": {
+      "type": "text"
+    },
+    "countryCode": {
+      "type": "text"
+    },
+    "externalId": {
+      "type": "text"
+    },
+    "location": {
+      "type": "geo_point"
+    },
+    "phone": {
+      "type": "text"
+    },
+    "postalCode": {
+      "type": "text"
+    },
+    "state": {
+      "type": "text"
+    },
+    "stateCode": {
+      "type": "text"
+    },
+    "storePhone": {
+      "type": "text"
+    }
+  }
+}

--- a/esconfig/elastic.schema.store.json
+++ b/esconfig/elastic.schema.store.json
@@ -24,9 +24,6 @@
     "location": {
       "type": "geo_point"
     },
-    "phone": {
-      "type": "text"
-    },
     "postalCode": {
       "type": "text"
     },

--- a/esconfig/elastic.schema.store.json
+++ b/esconfig/elastic.schema.store.json
@@ -3,38 +3,26 @@
     "storeCode": {
       "type": "keyword"
     },
-    "storeName": {
-      "type": "text"
+    "externalId": {
+      "type": "keyword"
     },
     "storeType": {
-      "type": "text"
+      "type": "keyword"
     },
-    "address1": {
-      "type": "text"
-    },
-    "city": {
-      "type": "text"
-    },
-    "countryCode": {
-      "type": "text"
-    },
-    "externalId": {
-      "type": "text"
+    "storePhone": {
+      "type": "keyword"
     },
     "location": {
       "type": "geo_point"
     },
-    "postalCode": {
-      "type": "text"
-    },
-    "state": {
-      "type": "text"
-    },
     "stateCode": {
-      "type": "text"
+      "type": "keyword"
     },
-    "storePhone": {
-      "type": "text"
+    "countryCode": {
+      "type": "keyword"
+    },
+    "postalCode": {
+      "type": "keyword"
     }
   }
 }

--- a/service/co/hotwax/oms/SearchServices.xml
+++ b/service/co/hotwax/oms/SearchServices.xml
@@ -39,7 +39,7 @@
     </service>
 
     <!-- Index Facility -->
-    <service verb="index" noun="FacilityDataDocuments">
+    <service verb="index" noun="FacilityDataDocuments" authenticate="anonymous-all">
         <description>
             The service will index Facility data documents and handle the save of facility's
             latitude and longitude data if existing, to index in the geo_point type location field.

--- a/service/co/hotwax/oms/SearchServices.xml
+++ b/service/co/hotwax/oms/SearchServices.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-2.1.xsd">
 
-    <!-- Service to create mappings, added for manually creating index for stores
-            due to the use of geo_point type location field -->
+    <!-- Service to create mappings, added for manually creating index, also needed to create
+        mappings for stores due to the use of geo_point type location field -->
     <service verb="create" noun="Mappings" authenticate="anonymous-all">
         <in-parameters>
             <parameter name="clusterName" default-value="default"/>
@@ -30,7 +30,7 @@
                             def docMapping = (Map) new JsonSlurper().parse(file);
                             elasticClient.createIndex(index, docMapping, null)
                         } catch (Exception e) {
-                            ec.logger.log(ec.logger.ERROR_INT, "Error creating mappings", e)
+                            ec.message.addError("Error creating mappings : ${e.getMessage()}")
                         }
                     }
                 }
@@ -39,9 +39,9 @@
     </service>
 
     <!-- Index Facility -->
-    <service verb="index" noun="FacilityDataDocuments" authenticate="anonymous-all">
+    <service verb="index" noun="StoreDataDocuments" authenticate="anonymous-all">
         <description>
-            The service will index Facility data documents and handle the save of facility's
+            The service will index store data documents and handle the save of store's
             latitude and longitude data if existing, to index in the geo_point type location field.
         </description>
         <implements service="org.moqui.EntityServices.receive#DataFeed"/>
@@ -49,14 +49,14 @@
             <parameter name="clusterName" default-value="default"/>
         </in-parameters>
         <actions>
-            <set field="indexName" value="store"/>
             <set field="elasticClient" from="ec.factory.elastic.getClient(clusterName)"/>
             <if condition="elasticClient == null">
                 <return type="danger" message="No Elastic Client found, not creating mapping"/>
             </if>
 
             <iterate list="documentList" entry="document">
-                <log level="info" message="Running ${indexName} index service for: ${document.facilityId} "/>
+                <log message="=== document: ${document} ======"/>
+                <log level="info" message="Running ${document._index} index service for: ${document.facilityId} "/>
 
                 <set field="facilityContactMechs" from="document.contactMechs"/>
                 <if condition="facilityContactMechs">
@@ -85,9 +85,9 @@
 
                 <script><![CDATA[
                     try {
-                        elasticClient.index(indexName, document.facilityId, source)
+                        elasticClient.index(document._index, document.facilityId, source)
                     } catch (Exception e) {
-                        ec.logger.log(ec.logger.ERROR_INT, "Error creating index", e)
+                        ec.message.addError("Error creating index : ${e.getMessage()}")
                     }
                 ]]></script>
             </iterate>

--- a/service/co/hotwax/oms/SearchServices.xml
+++ b/service/co/hotwax/oms/SearchServices.xml
@@ -55,7 +55,6 @@
             </if>
 
             <iterate list="documentList" entry="document">
-                <log message="=== document: ${document} ======"/>
                 <log level="info" message="Running ${document._index} index service for: ${document.facilityId} "/>
 
                 <set field="facilityContactMechs" from="document.contactMechs"/>

--- a/service/co/hotwax/oms/SearchServices.xml
+++ b/service/co/hotwax/oms/SearchServices.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-2.1.xsd">
+
+    <!-- Service to create mappings, added for manually creating index for stores
+            due to the use of geo_point type location field -->
+    <service verb="create" noun="Mappings" authenticate="anonymous-all">
+        <in-parameters>
+            <parameter name="clusterName" default-value="default"/>
+        </in-parameters>
+        <actions>
+            <set field="elasticClient" from="ec.factory.elastic.getClient(clusterName)"/>
+            <if condition="elasticClient == null">
+                <return type="danger" message="No Elastic Client found, not creating mapping"/>
+            </if>
+            <script><![CDATA[
+                import groovy.json.JsonSlurper;
+                // TODO Add logic to find in all the components and dynamically get configurations in esconfig
+                File esconfigs = new File((String) ec.factory.getRuntimePath() + "/component/oms/esconfig");
+
+                if (esconfigs.isDirectory()) {
+                    File[] files = esconfigs.listFiles();
+                    for (File file : files) {
+                        try {
+                            // File path is elastic.schema.<index name>.json.
+                            String filePath = file.getName();
+                            // Extracted <index name>.json
+                            String fileName = filePath.substring(filePath.substring(0, filePath.lastIndexOf(".")).lastIndexOf(".")+1);
+                            // Extracted <index name>
+                            String index = ((List) fileName.split("\\.")).get(0).toLowerCase();
+                            def docMapping = (Map) new JsonSlurper().parse(file);
+                            elasticClient.createIndex(index, docMapping, null)
+                        } catch (Exception e) {
+                            ec.logger.log(ec.logger.ERROR_INT, "Error creating mappings", e)
+                        }
+                    }
+                }
+            ]]></script>
+        </actions>
+    </service>
+
+    <!-- Index Facility -->
+    <service verb="index" noun="FacilityDataDocuments">
+        <description>
+            The service will index Facility data documents and handle the save of facility's
+            latitude and longitude data if existing, to index in the geo_point type location field.
+        </description>
+        <implements service="org.moqui.EntityServices.receive#DataFeed"/>
+        <in-parameters>
+            <parameter name="clusterName" default-value="default"/>
+        </in-parameters>
+        <actions>
+            <set field="indexName" value="store"/>
+            <set field="elasticClient" from="ec.factory.elastic.getClient(clusterName)"/>
+            <if condition="elasticClient == null">
+                <return type="danger" message="No Elastic Client found, not creating mapping"/>
+            </if>
+
+            <iterate list="documentList" entry="document">
+                <log level="info" message="Running ${indexName} index service for: ${document.facilityId} "/>
+
+                <set field="facilityContactMechs" from="document.contactMechs"/>
+                <if condition="facilityContactMechs">
+                    <set field="nowTime" from="new Timestamp(System.currentTimeMillis())"/>
+                    <set field="postalAddress" from="facilityContactMechs.find({ 'PostalPrimary'.equals(it.contactMechPurposeId) &amp;&amp; (it.fromDate == null || it.fromDate.compareTo(nowTime) &lt;= 0) &amp;&amp; (it.thruDate == null || it.thruDate.compareTo(nowTime) &gt; 0) })"/>
+
+                    <set field="telecomNumber" from="facilityContactMechs.find({ 'PhonePrimary'.equals(it.contactMechPurposeId) &amp;&amp; (it.fromDate == null || it.fromDate.compareTo(nowTime) &lt;= 0) &amp;&amp; (it.thruDate == null || it.thruDate.compareTo(nowTime) &gt; 0) })"/>
+                </if>
+
+                <set field="source" from="[storeCode:document.facilityId,
+                        storeName:document.facilityName,
+                        externalId:document.pseudoId,
+                        storeType:document.facilityTypeEnumId,
+                        address1:postalAddress ? postalAddress.address1 : null,
+                        city:postalAddress ? postalAddress.city : null,
+                        stateCode:postalAddress ? postalAddress.stateProvinceGeoId : null,
+                        state:postalAddress ? postalAddress.state : null,
+                        countryCode:postalAddress ? postalAddress.countyGeoId : null,
+                        country:postalAddress ? postalAddress.country : null,
+                        postalCode:postalAddress ? postalAddress.postalCode : null,
+                        storePhone:telecomNumber ? telecomNumber.contactNumber : null]"/>
+
+                <if condition="postalAddress &amp;&amp; postalAddress.latitude &amp;&amp; postalAddress.longitude">
+                    <set field="source.location" from="[lat:postalAddress.latitude, lon:postalAddress.longitude]"/>
+                </if>
+
+                <script><![CDATA[
+                    try {
+                        elasticClient.index(indexName, document.facilityId, source)
+                    } catch (Exception e) {
+                        ec.logger.log(ec.logger.ERROR_INT, "Error creating index", e)
+                    }
+                ]]></script>
+            </iterate>
+        </actions>
+    </service>
+</services>

--- a/service/co/hotwax/oms/SearchServices.xml
+++ b/service/co/hotwax/oms/SearchServices.xml
@@ -67,17 +67,17 @@
                 </if>
 
                 <set field="source" from="[storeCode:document.facilityId,
-                        storeName:document.facilityName,
-                        externalId:document.pseudoId,
-                        storeType:document.facilityTypeEnumId,
+                        storeName:document.storeName,
+                        externalId:document.externalId,
+                        storeType:document.storeType,
                         address1:postalAddress ? postalAddress.address1 : null,
                         city:postalAddress ? postalAddress.city : null,
-                        stateCode:postalAddress ? postalAddress.stateProvinceGeoId : null,
+                        stateCode:postalAddress ? postalAddress.stateCode : null,
                         state:postalAddress ? postalAddress.state : null,
-                        countryCode:postalAddress ? postalAddress.countyGeoId : null,
+                        countryCode:postalAddress ? postalAddress.countryCode : null,
                         country:postalAddress ? postalAddress.country : null,
                         postalCode:postalAddress ? postalAddress.postalCode : null,
-                        storePhone:telecomNumber ? telecomNumber.contactNumber : null]"/>
+                        storePhone:telecomNumber ? telecomNumber.storePhone : null]"/>
 
                 <if condition="postalAddress &amp;&amp; postalAddress.latitude &amp;&amp; postalAddress.longitude">
                     <set field="source.location" from="[lat:postalAddress.latitude, lon:postalAddress.longitude]"/>


### PR DESCRIPTION
Implement API to search stores close to a given latitude and longitude within a given distance from the user, or based on other parameters like store name, store type, city, state, country, postal code etc.

Implementation Done:
1. Added schema for store with location field of geo_point type to enable geo spatial queries to find stores.
2. The store mapping with location geo_point field needs to be created manually first, as the dynamic mapping will not work. Reference: https://www.baeldung.com/elasticsearch-geo-spatial.
3. Created Data Document for Store using facility and related entities. including the fields for basic store details, address and latitude, longitude fields.
3. For indexing store data, added the data feed service with real time push, and custom index service to index the store data with location field, as it expects the latitude, longitude data in certain format.
4. The index service will save the data for geo-point location as an object with latitude and longitude as keys. 
`{
    "location": { 
        "lat": 23.02,
        "lon": 72.57
    }
}`
5. As the store data is indexed with location geo_point values, we can use the geo distance query to search stores.

cc @janvi04 