### PR TITLE
Implemented: Product Inventory API using Product Facility extended with last and computed inventory counts

### DIFF
--- a/data/OmsDocumentData.xml
+++ b/data/OmsDocumentData.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="seed-initial">
+
+    <!-- Product Facility Document Data -->
+    <dataDocuments dataDocumentId="ProductFacility" indexName="product_inventory" documentName="Product Facility"
+            primaryEntityName="mantle.facility.ProductFacility" documentTitle="${productId}:${facilityId}">
+        <fields fieldSeqId="01" fieldPath="productId"/>
+        <fields fieldSeqId="02" fieldPath="facilityId"/>
+        <fields fieldSeqId="03" fieldPath="minimumStock"/>
+        <fields fieldSeqId="04" fieldPath="lastInventoryCount"/>
+        <fields fieldSeqId="05" fieldPath="computedLastInventoryCount"/>
+    </dataDocuments>
+
+    <!-- Product Facility DataFeed -->
+    <moqui.entity.feed.DataFeed dataFeedId="ProductFacilitySearch" dataFeedTypeEnumId="DTFDTP_RT_PUSH"
+            feedName="Product Facility Search Data" feedReceiveServiceName="org.moqui.search.SearchServices.index#DataDocuments">
+        <documents dataDocumentId="ProductFacility"/>
+    </moqui.entity.feed.DataFeed>
+</entity-facade-xml>

--- a/entity/Asset.eecas.xml
+++ b/entity/Asset.eecas.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <eecas xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/entity-eca-2.1.xsd">
 
-    <!-- Update the last Inventory and computed Inventory count when inventory is updated in system -->
+    <!-- Update the product's last Inventory and computed Inventory when inventory is updated in system -->
     <eeca id="AssetDetailUpdateInventoryCount" entity="mantle.product.asset.AssetDetail" on-create="true">
         <actions>
-            <service-call name="co.hotwax.oms.AssetServices.update#InventoryCountFromDetail" in-map="context"/>
+            <service-call name="co.hotwax.oms.AssetServices.update#ProductInventory" in-map="context"/>
         </actions>
     </eeca>
 </eecas>

--- a/entity/Asset.eecas.xml
+++ b/entity/Asset.eecas.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eecas xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/entity-eca-2.1.xsd">
+
+    <!-- Update the last Inventory and computed Inventory count when inventory is updated in system -->
+    <eeca id="AssetDetailUpdateInventoryCount" entity="mantle.product.asset.AssetDetail" on-create="true">
+        <actions>
+            <service-call name="co.hotwax.oms.AssetServices.update#InventoryCountFromDetail" in-map="context"/>
+        </actions>
+    </eeca>
+</eecas>

--- a/entity/FacilityEntities.xml
+++ b/entity/FacilityEntities.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/entity-definition-2.1.xsd">
+
+    <!-- Extended Product Facility to store the inventory counts -->
+    <!-- Note: computedLastInventoryCount will be the count excluding the minimumStock in ProductFacility -->
+    <extend-entity entity-name="ProductFacility" package="mantle.facility">
+        <field name="lastInventoryCount" type="number-decimal"/>
+        <field name="computedLastInventoryCount" type="number-decimal"/>
+    </extend-entity>
+</entities>

--- a/service/co/hotwax/oms/AssetServices.xml
+++ b/service/co/hotwax/oms/AssetServices.xml
@@ -194,7 +194,7 @@
         </actions>
     </service>
 
-    <service verb="update" noun="InventoryCountFromDetail" authenticate="anonymous-all">
+    <service verb="update" noun="ProductInventory" authenticate="anonymous-all">
         <description>
             The service will update the inventory counts for a product at a facility based on the
             availableToPromiseDiff from Asset Detail, taking in consideration the minimum stock value

--- a/service/co/hotwax/oms/AssetServices.xml
+++ b/service/co/hotwax/oms/AssetServices.xml
@@ -194,4 +194,46 @@
         </actions>
     </service>
 
+    <service verb="update" noun="InventoryCountFromDetail" authenticate="anonymous-all">
+        <description>
+            The service will update the inventory counts for a product at a facility based on the
+            availableToPromiseDiff from Asset Detail, taking in consideration the minimum stock value
+            if existing.
+        </description>
+        <in-parameters>
+            <parameter name="assetId" required="true"/>
+            <parameter name="productId"/>
+            <parameter name="availableToPromiseDiff" type="BigDecimal"/>
+        </in-parameters>
+        <actions>
+            <!-- Find Asset, this is needed to get the facilityId for which product's inv is updated -->
+            <entity-find entity-name="mantle.product.asset.Asset" list="assetList">
+                <econdition field-name="assetId"/>
+                <econdition field-name="assetTypeEnumId" value="AstTpInventory"/>
+            </entity-find>
+
+            <if condition="assetList">
+                <!-- Find Product Facility -->
+                <entity-find-one entity-name="mantle.facility.ProductFacility" value-field="productFacility" for-update="true">
+                    <field-map field-name="productId"/>
+                    <field-map field-name="facilityId" from="assetList.first?.facilityId"/>
+                </entity-find-one>
+
+                <if condition="!productFacility">
+                    <return type="warning" message="Product Facility not found for product ${productId} and facility ${assetList.first?.facilityId}, not updating inventory counts."/>
+                </if>
+
+                <set field="minimumStock" from="productFacility ? productFacility.minimumStock : 0" type="Integer"/>
+
+                <!-- lastInventoryCount is the latest inventory count for the product at a facility -->
+                <set field="productFacility.lastInventoryCount" from="(productFacility.lastInventoryCount ?: 0.0) + availableToPromiseDiff"/>
+
+                <!-- computedLastInventoryCount is the inventory excluding the minimum stock if set in the Product Facility -->
+                <set field="productFacility.computedLastInventoryCount" from="minimumStock ? productFacility.lastInventoryCount - minimumStock : productFacility.lastInventoryCount"/>
+
+                <!-- Update the inventory counts in Product Facility-->
+                <entity-update value-field="productFacility"/>
+            </if>
+        </actions>
+    </service>
 </services>


### PR DESCRIPTION
Implement API to return the product inventory information for the product at a store(s).

Implementation Done:
1. Extend ProductFacility entity to include lastInventoryCount and computedLastInventoryCount fields.
2. The lastInventoryCount is the latest available to promise count for the product at a facility.
3. The computedLastInventoryCount is the inventory excluding the minimum stock if set for the product facility.
4. eeca on AssetDetail to update the inventory counts in Product Facility.
5. For querying the product inventory, created Data Document for ProductFacility. This will be the index to query the inventory information. 
6. The Data Feed will use the OOTB index#DataDocuments services and index all records.
7. The fields included in the data document/product_inventory index are:
    - productId
    - facilityId
    - minimumStock
    - lastInventoryCount
    - computedLastInventoryCount
8. With OOTB indexing, we can use the product_inventory index from data document to query the inventory of a product.