### PR TITLE
Implemented: Search API for OMS as single end point to return results from Elasticsearch

### DIFF
--- a/service/co/hotwax/oms/SearchServices.xml
+++ b/service/co/hotwax/oms/SearchServices.xml
@@ -23,9 +23,6 @@
             <parameter name="aggregations"/>
         </out-parameters>
         <actions>
-            <log message="===== inside search#OmsData service ======"/>
-            <log message="=== indexName: ${indexName} ======="/>
-
             <script><![CDATA[
                 import groovy.json.JsonSlurper
                 try {

--- a/service/co/hotwax/oms/SearchServices.xml
+++ b/service/co/hotwax/oms/SearchServices.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-2.1.xsd">
+
+    <service verb="search" noun="OmsData">
+        <description>
+            The service will perform search on the provided elastic index name.
+        </description>
+        <in-parameters>
+            <parameter name="indexName" required="true"/>
+            <parameter name="_source_include"/>
+            <parameter name="_source_exclude"/>
+            <parameter name="from"/>
+            <parameter name="request"/>
+            <parameter name="size"/>
+            <parameter name="sort"/>
+            <parameter name="clusterName" default-value="default"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="took"/>
+            <parameter name="timed_out"/>
+            <parameter name="_shards"/>
+            <parameter name="hits"/>
+            <parameter name="aggregations"/>
+        </out-parameters>
+        <actions>
+            <log message="===== inside search#OmsData service ======"/>
+            <log message="=== indexName: ${indexName} ======="/>
+
+            <script><![CDATA[
+                import groovy.json.JsonSlurper
+                try {
+                def Map params = [:]
+                if (request) params.putAll((Map) new  JsonSlurper().parseText(URLDecoder.decode(request)))
+                if (_source_include || _source_exclude) {
+                    Map sourceMap = [:];
+                    if (_source_include) sourceMap.put("includes", _source_include.split(",") as List);
+                    if (_source_exclude) sourceMap.put("excludes", _source_exclude.split(",") as List)
+                    params.put("_source", sourceMap);
+                }
+                if (from) params.put("from", from)
+                if (size) params.put("size", size)
+                if (sort) {
+                    def sortFields = sort.split(":");
+                    def sortBy = sortFields[0];
+                    def sortMap = [:];
+                    def sortOrder = (sortFields.length > 1)?sortFields[1]: "asc";
+                    sortMap.put(sortBy, sortOrder);
+                    params.put("sort", sortMap);
+                }
+                def elasticClient = ec.factory.elastic.getClient(clusterName)
+                def Map resultMap = elasticClient.search(indexName, params)
+                context.putAll(resultMap)
+                } catch (Exception e) {
+                    ec.logger.error("Error in ElasticSearch : ${e.getMessage()}")
+                }
+            ]]></script>
+        </actions>
+    </service>
+</services>

--- a/service/oms.rest.xml
+++ b/service/oms.rest.xml
@@ -7,6 +7,13 @@
     <resource name="lookup" description="Lookup from various entities by ID">
         <method type="get"><service name="mantle.GeneralServices.lookup#ById"/></method>
     </resource>
+
+    <resource name="_search" require-authentication="anonymous-view">
+        <!-- TODO check for passing dynamic values in resource name to perform search on single
+                end point like /_search/store or /_search/product_inventory -->
+        <!-- For now added indexName parameter in service to identify the index to search on -->
+        <method type="get"><service name="co.hotwax.oms.SearchServices.search#OmsData"/></method>
+    </resource>
     
     <resource name="orders">
         <method type="get"><service name="co.hotwax.oms.OrderServices.find#Orders"/></method>


### PR DESCRIPTION
Implement single end-point for OMS search using elastic.
The API end-point will internally perform search on the elastic indices and return the data. 

1. Added new end-point for search data using Elastic in OMS.
2. Added service to perform and return results using Elasticsearch as implementation for the API end-point.
3. For now, the end-point will use indexName parameter as passed to the API. 
