### PR TITLE
Improved: Added minimum stock level setting data and included all OOTB record inventoryPhysicalQuantity params to record inventory

### DIFF
--- a/data/OmsAaaSetupData.xml
+++ b/data/OmsAaaSetupData.xml
@@ -16,4 +16,6 @@
     <moqui.basic.Enumeration description="Retail Store" enumCode="STORE" enumId="FcTpRetailStore" enumTypeId="FacilityType"/>
     <moqui.basic.Enumeration description="Warehouse" enumCode="WAREHOUSE" enumId="FcTpWarehouse" enumTypeId="FacilityType"/>
 
+    <!-- Store Setting for Minimum Stock Quantity for products -->
+    <moqui.basic.Enumeration description="Minimum Stock Level" enumId="PsstMinimumStockLevel" enumTypeId="ProductStoreSettingType"/>
 </entity-facade-xml>

--- a/service/co/hotwax/oms/AssetServices.xml
+++ b/service/co/hotwax/oms/AssetServices.xml
@@ -7,6 +7,7 @@
             Sets the total inventory count for a product at a fulfillment location.
             This requires either productId or SKU, either locationId or facilityId and available quantity of the product.
         </description>
+        <implements service="mantle.product.AssetServices.record#PhysicalInventoryQuantity" required="false"/>
         <in-parameters>
             <parameter name="productId">
                 <description>The ID of the product in the system.</description>
@@ -23,22 +24,6 @@
             <parameter name="quantity" type="Integer" required="true">
                 <description>The total quantity of the product available at the fulfillment location.</description>
             </parameter>
-            <parameter name="varianceReasonEnumId">
-                <description>The ID for the reason to record inventory for the product.</description>
-            </parameter>
-            <parameter name="physicalInventoryId"/>
-            <parameter name="physicalInventoryCountId"/>
-            <parameter name="partyId" default="ec.user.userAccount?.partyId"/>
-            <parameter name="physicalInventoryDate" type="Timestamp" default="ec.user.nowTimestamp"/>
-            <parameter name="comments"/>
-            <auto-parameters entity-name="mantle.product.asset.Asset" include="nonpk">
-                <exclude field-name="classEnumId"/>
-                <exclude field-name="quantityOnHandTotal"/>
-                <exclude field-name="availableToPromiseTotal"/>
-                <exclude field-name="hasQuantity"/>
-                <exclude field-name="receivedDate"/>
-                <exclude field-name="acquiredDate"/>
-            </auto-parameters>
         </in-parameters>
         <out-parameters>
             <parameter name="productId">

--- a/service/co/hotwax/oms/AssetServices.xml
+++ b/service/co/hotwax/oms/AssetServices.xml
@@ -23,6 +23,22 @@
             <parameter name="quantity" type="Integer" required="true">
                 <description>The total quantity of the product available at the fulfillment location.</description>
             </parameter>
+            <parameter name="varianceReasonEnumId">
+                <description>The ID for the reason to record inventory for the product.</description>
+            </parameter>
+            <parameter name="physicalInventoryId"/>
+            <parameter name="physicalInventoryCountId"/>
+            <parameter name="partyId" default="ec.user.userAccount?.partyId"/>
+            <parameter name="physicalInventoryDate" type="Timestamp" default="ec.user.nowTimestamp"/>
+            <parameter name="comments"/>
+            <auto-parameters entity-name="mantle.product.asset.Asset" include="nonpk">
+                <exclude field-name="classEnumId"/>
+                <exclude field-name="quantityOnHandTotal"/>
+                <exclude field-name="availableToPromiseTotal"/>
+                <exclude field-name="hasQuantity"/>
+                <exclude field-name="receivedDate"/>
+                <exclude field-name="acquiredDate"/>
+            </auto-parameters>
         </in-parameters>
         <out-parameters>
             <parameter name="productId">


### PR DESCRIPTION
1. For the service for recording inventory in OMS, added the input parameters as in the OOTB service of record#PhysicalInventoryQuantity which is called inline in our service.

2. This way we don't need to add custom services for specific inputs to the record inventory service, and it becomes a wrapper service in OMS for recording inventory quantity for the product.

3. We will be able to pass the field values for comments, varianceReasonEnumId etc. in our OMS service only, keeping the schema as defined by the inventory API.