### PR TITLE
Fixed: Duplicate index issue when running create#Mappings service for Store Locator API

### DIFF
--- a/data/OmsDocumentData.xml
+++ b/data/OmsDocumentData.xml
@@ -9,7 +9,7 @@
     <co.hotwax.oms.SearchServices.createMappings clusterName="default"/>
 
     <!-- ========== Store Document Data ========== -->
-    <dataDocuments dataDocumentId="StoreDataDocument" indexName="store_document" documentName="Store"
+    <dataDocuments dataDocumentId="StoreDataDocument" indexName="store" documentName="Store"
             primaryEntityName="mantle.facility.Facility" documentTitle="${facilityId}">
         <fields fieldSeqId="01" fieldPath="facilityId"/>
         <fields fieldSeqId="02" fieldPath="pseudoId" fieldNameAlias="externalId"/>

--- a/data/OmsDocumentData.xml
+++ b/data/OmsDocumentData.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <entity-facade-xml type="seed-initial">
 
+    <!-- Added below service call in data file, which will run the create#Mappings service
+        to create the store index, this is needed for the special geo_point type location field.
+        Note: This is added here to run before data document load, else the StoreDataDocument can create
+        the index with default mappings if any facility data loaded as part of the project, and this
+        will return error if create#Mappings service is run manually after the data load. -->
+    <co.hotwax.oms.SearchServices.createMappings clusterName="default"/>
+
     <!-- ========== Store Document Data ========== -->
-    <dataDocuments dataDocumentId="StoreDataDocument" indexName="store" documentName="Store"
+    <dataDocuments dataDocumentId="StoreDataDocument" indexName="store_document" documentName="Store"
             primaryEntityName="mantle.facility.Facility" documentTitle="${facilityId}">
         <fields fieldSeqId="01" fieldPath="facilityId"/>
         <fields fieldSeqId="02" fieldPath="pseudoId" fieldNameAlias="externalId"/>

--- a/service/co/hotwax/oms/SearchServices.xml
+++ b/service/co/hotwax/oms/SearchServices.xml
@@ -49,13 +49,14 @@
             <parameter name="clusterName" default-value="default"/>
         </in-parameters>
         <actions>
+            <set field="indexName" value="store"/>
             <set field="elasticClient" from="ec.factory.elastic.getClient(clusterName)"/>
             <if condition="elasticClient == null">
                 <return type="danger" message="No Elastic Client found, not creating mapping"/>
             </if>
 
             <iterate list="documentList" entry="document">
-                <log level="info" message="Running ${document._index} index service for: ${document.facilityId} "/>
+                <log level="info" message="Running ${indexName} index service for: ${document.facilityId} "/>
 
                 <set field="facilityContactMechs" from="document.contactMechs"/>
                 <if condition="facilityContactMechs">
@@ -84,7 +85,7 @@
 
                 <script><![CDATA[
                     try {
-                        elasticClient.index(document._index, document.facilityId, source)
+                        elasticClient.index(indexName, document.facilityId, source)
                     } catch (Exception e) {
                         ec.message.addError("Error creating index : ${e.getMessage()}")
                     }

--- a/service/co/hotwax/oms/SearchServices.xml
+++ b/service/co/hotwax/oms/SearchServices.xml
@@ -49,14 +49,13 @@
             <parameter name="clusterName" default-value="default"/>
         </in-parameters>
         <actions>
-            <set field="indexName" value="store"/>
             <set field="elasticClient" from="ec.factory.elastic.getClient(clusterName)"/>
             <if condition="elasticClient == null">
                 <return type="danger" message="No Elastic Client found, not creating mapping"/>
             </if>
 
             <iterate list="documentList" entry="document">
-                <log level="info" message="Running ${indexName} index service for: ${document.facilityId} "/>
+                <log level="info" message="Running ${document._index} index service for: ${document.facilityId} "/>
 
                 <set field="facilityContactMechs" from="document.contactMechs"/>
                 <if condition="facilityContactMechs">
@@ -85,7 +84,7 @@
 
                 <script><![CDATA[
                     try {
-                        elasticClient.index(indexName, document.facilityId, source)
+                        elasticClient.index(document._index, document.facilityId, source)
                     } catch (Exception e) {
                         ec.message.addError("Error creating index : ${e.getMessage()}")
                     }


### PR DESCRIPTION
1. Added fix for the error: Invalid index name [store], already exists as alias. This is due to the same indexName, "store" used for data document and custom indexing.

2. Added the create Mappings service call in the seed-initial data file, which will run before data document load and create the index with the required data mapping.
- This is done for the scenario, If an existing facility data in the seed/seed-initial files, like NA facility, this will create issue and again throw error when create#Mappings service will be called after data load. As due to existing data, it will create the index, and when create mappings service is called, it returns the error that cannot update index.
