### PR TITLE
Improved: Added handling to exclude NA facility in the Store Locator API

### DIFF
--- a/data/OmsDocumentData.xml
+++ b/data/OmsDocumentData.xml
@@ -33,6 +33,9 @@
 
         <fields fieldSeqId="19" fieldPath="contactMechs:postalAddress:geoPoint:latitude"/>
         <fields fieldSeqId="20" fieldPath="contactMechs:postalAddress:geoPoint:longitude"/>
+
+        <conditions conditionSeqId="01" fieldNameAlias="storeName" operator="not-equals" fieldValue="NA Facility"/>
+
     </dataDocuments>
 
     <!-- Search Data Feed for Stores -->

--- a/data/OmsDocumentData.xml
+++ b/data/OmsDocumentData.xml
@@ -34,8 +34,7 @@
         <fields fieldSeqId="19" fieldPath="contactMechs:postalAddress:geoPoint:latitude"/>
         <fields fieldSeqId="20" fieldPath="contactMechs:postalAddress:geoPoint:longitude"/>
 
-        <conditions conditionSeqId="01" fieldNameAlias="storeName" operator="not-equals" fieldValue="NA Facility"/>
-
+        <conditions conditionSeqId="01" fieldNameAlias="facilityId" operator="not-equals" fieldValue="_NA_"/>
     </dataDocuments>
 
     <!-- Search Data Feed for Stores -->


### PR DESCRIPTION
1. The _NA_ facility is a facility used for internal purposes in the source code.
2. This is not a store or any fulfillment location from which an order should be fulfilled that's why it should not appear in the store locator API.

**Changes done:**
1. Updated the OmsDocumentData file to add the condition in the store data document to exclude the _NA_facility in the store locator API.

**Note:-**
1. The data document should be reloaded and data feed has to be manually run for this change.
2. If the index is already created before this change, it is observed that all the facility records will appear in the Store locator API response including the _NA_ facility record, as already indexed data satisfying the condition will not be removed automatically.
3. For the API to correctly index records excluding NA facility, the index will have to be deleted and re-created.
4. Load the data document with latest changes. 
5. Run the data feed with Id, "StoreSearch".
