### PR TITLE
Updated: called the indexing service in a new transaction

### DIFF
--- a/service/co/hotwax/oms/search/SearchServices.xml
+++ b/service/co/hotwax/oms/search/SearchServices.xml
@@ -22,7 +22,7 @@ under the License.
             <iterate list="documentList" entry="dataDocument">
                 <log level="info" message="Creating product index for oms productId : ${dataDocument._id}"/>
                 <service-call name="co.hotwax.oms.search.SearchServices.call#CreateProductIndex" in-map="[productId:dataDocument._id]"
-                              async="true"/>
+                        transaction="force-new" ignore-error="true"/>
             </iterate>
         </actions>
     </service>


### PR DESCRIPTION
Updated the code to call the product indexing service in a new transaction instead of calling it async.