### PR TITLE
Worked on following:

### DIFF
--- a/service/co/hotwax/oms/impl/OrderReservationServices.xml
+++ b/service/co/hotwax/oms/impl/OrderReservationServices.xml
@@ -468,8 +468,6 @@
                                 shipmentMethodTypeId: suggestedShipMethodTypeId,
                                 routerUserLogin:ec.user.username, changeDatetime: ec.user.nowTimestamp]"/>
 
-            <service-call name="co.hotwax.oms.search.SearchServices.index#OrderItem" in-map="[orderId:orderId, orderItemSeqId: orderItemSeqId]"
-                          ignore-error="true"/>
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/oms/search/SearchServices.xml
+++ b/service/co/hotwax/oms/search/SearchServices.xml
@@ -35,7 +35,7 @@ under the License.
             <parameter name="response" type="Map"/>
         </out-parameters>
     </service>
-    <service verb="index" noun="OrderItem" type="oms-rest" location="service/createOrderIndex" method="post">
+    <service verb="index" noun="OrderItem" type="oms-rest" location="service/createOrderIndex" method="post" authenticate="anonymous-view">
         <description>Create order index</description>
         <in-parameters>
             <parameter name="orderId" required="true"/>
@@ -45,7 +45,7 @@ under the License.
             <parameter name="response" type="Map"/>
         </out-parameters>
     </service>
-    <service verb="index" noun="OrderHeader" type="oms-rest" location="service/createOrderIndex" method="post">
+    <service verb="index" noun="OrderHeader" type="oms-rest" location="service/createOrderIndex" method="post" authenticate="anonymous-view">
         <description>Create order index</description>
         <in-parameters>
             <parameter name="orderId" required="true"/>

--- a/service/oms.secas.xml
+++ b/service/oms.secas.xml
@@ -1,0 +1,10 @@
+<secas xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-eca-3.xsd">
+
+    <seca id="ProcessOrderItemAllocation" service="co.hotwax.oms.impl.OrderReservationServices.process#OrderItemAllocation" when="tx-commit">
+        <condition><expression>allocatedShipGroupSeqId</expression></condition>
+        <actions>
+            <service-call name="co.hotwax.oms.search.SearchServices.index#OrderItem" in-map="[orderId:orderId, orderItemSeqId: orderItemSeqId]"
+                    ignore-error="true" />
+        </actions>
+    </seca>
+</secas>


### PR DESCRIPTION
- Set authenticate=anonymous-view to call the index service as tx-commit seca rule.
- Remove the inline order item index call while allocating facility to order item
- Added seca rule to call the order item index, ideally this should be done via DataDocument feature, will migrate the seca rule to DataDocument