### PR TITLE
121 add reject order item service

### DIFF
--- a/service/co/hotwax/oms/impl/OrderReservationServices.xml
+++ b/service/co/hotwax/oms/impl/OrderReservationServices.xml
@@ -86,6 +86,17 @@
             <parameter name="orderItemSeqId" required="true"/>
             <parameter name="cancelQuantity" type="BigDecimal" required="true" default-value="1"/>
         </in-parameters>
+        <out-parameters>
+            <parameter name="cancelledReservations" type="List">
+                <parameter name="cancelledReservation">
+                    <parameter name="orderId"/>
+                    <parameter name="orderItemSeqId"/>
+                    <parameter name="shipGroupSeqId"/>
+                    <parameter name="inventoryItemId"/>
+                    <parameter name="cancelledQuantity" type="BigDecimal"/>
+                </parameter>
+            </parameter>
+        </out-parameters>
         <actions>
             <entity-find-one entity-name="co.hotwax.order.OrderItemAndShipGroup" value-field="orderItem">
                 <field-map field-name="orderId" from="orderId"/>
@@ -127,13 +138,16 @@
                     </script>
                 </else>
             </if>
+            <set field="cancelledReservations" from="[]"/>
             <iterate list="reservedItems" entry="reservedItem">
                 <service-call name="co.hotwax.oms.product.ProductServices.findOrCreate#FacilityInventoryItem"
                         in-map="[productId: reservedItem.productId, facilityId: orderItem.facilityId]"
                         out-map="findOrCreateResult"/>
 
                 <set field="inventoryItemId" from="findOrCreateResult.inventoryItemId"/>
-
+                <script>
+                    cancelledReservations.add([orderId: orderId, orderItemSeqId:orderItemSeqId, inventoryItemId:inventoryItemId, shipGroupSeqId: orderItem.shipGroupSeqId, cancelledQuantity: reservedItem.cancelQuantity])
+                </script>
                 <set field="createDetailMap" from="[:]"/>
                 <set field="createDetailMap.inventoryItemId" from="inventoryItemId"/>
                 <set field="createDetailMap.orderId" from="orderId"/>

--- a/service/co/hotwax/oms/order/OrderServices.xml
+++ b/service/co/hotwax/oms/order/OrderServices.xml
@@ -58,38 +58,6 @@ under the License.
         </actions>
     </service>
 
-    <service verb="cancel" noun="OrderItemInvResQty" authenticate="anonymous-all">
-        <description>Cancel inventory reservation for an order item</description>
-        <in-parameters>
-            <parameter name="orderId" required="true"/>
-            <parameter name="orderItemSeqId" required="true"/>
-            <parameter name="shipGroupSeqId" required="true"/>
-        </in-parameters>
-        <actions>
-            <!-- Find all the reservation records from the OrderItemShipGrpInvRes entity -->
-            <entity-find entity-name="org.apache.ofbiz.order.order.OrderItemShipGrpInvRes" list="oisgirs">
-                <econdition field-name="orderId" from="orderId"/>
-                <econdition field-name="orderItemSeqId" from="orderItemSeqId"/>
-                <econdition field-name="shipGroupSeqId" from="shipGroupSeqId"/>
-            </entity-find>
-
-            <if condition="!oisgirs">
-                <return type="info" message="Order Reservations [OrderItem ID: ${orderId}:${orderItemSeqId}] - Not found"/>
-            </if>
-
-            <!-- Iterate each OISGIR record and delete it; ideally it will have 1 record-->
-            <iterate list="oisgirs" entry="oisgir">
-                <!-- get the inventoryItemId from the OISGIR record, so we can record the changes in InventoryItemDetail -->
-                <set field="inventoryItemId" from="oisgir.inventoryItemId" />
-                <entity-delete value-field="oisgir"/>
-
-                <!-- Call create#InventoryItemDetail inline to register the inventoryItem change and mark it available for reservation -->
-                <service-call name="create#org.apache.ofbiz.product.inventory.InventoryItemDetail" in-map="[inventoryItemId:inventoryItemId, effectiveDate:ec.user.nowTimestamp, quantityOnHandDiff:0, availableToPromiseDiff:1, accountingQuantityDiff:0, orderId:orderId, description: 'Cancelled item to order: ' + orderId + ', item: ' + orderItemSeqId]"/>
-            </iterate>
-
-        </actions>
-    </service>
-
     <service verb="change" noun="OrderItemStatus">
         <description>Change the status of a sales order item</description>
         <in-parameters>

--- a/service/co/hotwax/oms/order/OrderServices.xml
+++ b/service/co/hotwax/oms/order/OrderServices.xml
@@ -385,7 +385,7 @@ under the License.
             <service-call name="co.hotwax.poorti.FulfillmentServices.update#OrderItemFulfillmentStatus"
                           in-map="[orderId:orderId,orderItemSeqId:orderItemSeqId,facilityId:rejectToFacilityId,fulfillmentStatus:'Rejected']"/>
             <!--6. Record inventory variance-->
-            <entity-find-one entity-name="moqui.basic.Enumeration" value-field="enumMap" cache="true">
+            <entity-find-one entity-name="moqui.basic.Enumeration" value-field="rejectionEnum" cache="true">
                 <field-map field-name="enumId" from="rejectionReasonId"/>
             </entity-find-one>
             <entity-find-one entity-name="co.hotwax.oms.product.inventory.ProductFacilityInventoryItemView" value-field="productFacility">
@@ -393,13 +393,12 @@ under the License.
                 <field-map field-name="facilityId" from="facilityId"/>
             </entity-find-one>
 
-            <set field="enumType" from="enumMap.enumTypeId"/>
             <set field="varianceQuantity" value="0" type="BigDecimal"/>
-            <if condition="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'moqui.basic.EnumerationType', 'enumTypeId', 'REPORT_NO_VAR', 'parentTypeId', 'REPORT_NO_VAR')">
+            <if condition="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'moqui.basic.EnumerationType', 'enumTypeId', rejectionEnum.enumTypeId, 'parentTypeId', 'REPORT_NO_VAR')">
                 <return message="Item rejected successfully to facility: $rejectToFacilityId}" type="success"/>
-            <else-if condition="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'moqui.basic.EnumerationType', 'enumTypeId', 'REPORT_NO_VAR', 'parentTypeId', 'REPORT_VAR')">
+            <else-if condition="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'moqui.basic.EnumerationType', 'enumTypeId', rejectionEnum.enumTypeId, 'parentTypeId', 'REPORT_VAR')">
                     <set field="varianceQuantity" from="orderItem.quantity" type="BigDecimal"/>
-                <else-if condition="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'moqui.basic.EnumerationType', 'enumTypeId', 'REPORT_NO_VAR', 'parentTypeId', 'REPORT_ALL_VAR')">
+                <else-if condition="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'moqui.basic.EnumerationType', 'enumTypeId', rejectionEnum.enumTypeId, 'parentTypeId', 'REPORT_ALL_VAR')">
                     <set field="varianceQuantity" from="productFacility.lastInventoryCount" type="BigDecimal"/>
                 </else-if>
             </else-if>

--- a/service/co/hotwax/oms/order/OrderServices.xml
+++ b/service/co/hotwax/oms/order/OrderServices.xml
@@ -359,67 +359,23 @@ under the License.
         <in-parameters>
             <parameter name="orderId" required="true"/>
             <parameter name="orderItemSeqId" required="true"/>
-            <parameter name="facilityId" required="true"/>
             <parameter name="rejectToFacilityId" default-value="REJECTED_ITM_PARKING"/>
             <parameter name="recordVariance" default-value="Y"/>
             <parameter name="updateQOH" default-value="false" type="Boolean"/>
             <parameter name="rejectionReasonId" required="true"/>
             <parameter name="rejectComments" />
-            <parameter name="shipmentId"/>
-            <parameter name="shipmentItemSeqId"/>
         </in-parameters>
         <out-parameters>
-            <parameter name="cancelledReservations" type="Map"/>
+            <parameter name="cancelledReservations" type="Map">
+
+            </parameter>
         </out-parameters>
         <actions>
-
-            <!-- Check for shipment rejection -->
-            <if condition="shipmentId &amp;&amp; shipmentItemSeqId">
-
-                <!--Fetch the Shipment record using shipmentId.-->
-                <entity-find-one entity-name="org.apache.ofbiz.shipment.shipment.Shipment" value-field="shipment">
-                    <field-map field-name="shipmentId"/>
-                </entity-find-one>
-                <if condition="!shipment">
-                    <return error="true" message="Not a valid shipment: Shipment with ${shipmentId} does not exist"/>
-                </if>
-
-                <if condition="!shipment.statusId.equals('SHIPMENT_INPUT')">
-                    <service-call name="co.hotwax.poorti.FulfillmentServices.reinitialize#Shipment"
-                                  in-map="[shipmentId:shipmentId]"/>
-                </if>
-
-                <entity-find entity-name="org.apache.ofbiz.shipment.shipment.ShipmentPackageContent" list="shipmentPackageContentList">
-                    <econdition field-name="shipmentId"/>
-                    <econdition field-name="shipmentItemSeqId"/>
-                </entity-find>
-
-                <set field="shipmentPackageContent" from="shipmentPackageContentList[0]"/>
-
-                <!--            delete shipmentContent -->
-                <service-call name="delete#org.apache.ofbiz.shipment.shipment.ShipmentPackageContent"
-                              in-map="shipmentPackageContent"/>
-
-                <!--            delete shipmentItem -->
-                <service-call name="delete#org.apache.ofbiz.shipment.shipment.ShipmentItem"
-                              in-map="[shipmentId:shipmentId,shipmentItemSeqId:shipmentItemSeqId]"/>
-
-                <set field="facilityId" from="shipment?.originFacilityId"/>
-
-                <!--Query Order Shipment to get order related details from this shipment-->
-                <entity-find entity-name="org.apache.ofbiz.order.order.OrderShipment" list="orderShipmentList">
-                    <econdition field-name="shipmentId"/>
-                    <econdition field-name="shipmentItemSeqId"/>
-                    <econdition field-name="orderId"/>
-                </entity-find>
-
-                <set field="orderShipment" from="orderShipmentList[0]"/>
-
-                <!-- delete orderShipment -->
-                <service-call name="delete#org.apache.ofbiz.order.order.OrderShipment"
-                              in-map="orderShipment"/>
+            <set field="hasParentType"
+                 from="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'org.apache.ofbiz.product.facility.FacilityType', 'facilityTypeId', rejectToFacilityId, 'parentTypeId', 'VIRTUAL_FACILITY')" type="Boolean"/>
+            <if condition="!hasParentType">
+                <return error="true" message="Order item [${orderId}:${orderItemSeqId} can't be rejected to non virtual facility]"/>
             </if>
-
             <!--Fetch shipGroupSeqId of item before processing anything -->
             <entity-find-one entity-name="org.apache.ofbiz.order.order.OrderItem" value-field="orderItem">
                 <field-map field-name="orderId" from="orderId"/>
@@ -429,48 +385,28 @@ under the License.
             <set field="shipGroupSeqId" from="orderItem.shipGroupSeqId"/>
 
             <!--1. Cancel Inventory Reservation call cancel#OrderItemShipGrpInvRes -->
-            <service-call name="co.hotwax.oms.impl.OrderReservationServices.cancel#OrderItemInventoryReservation" in-map="[orderId:orderId,
-            orderItemSeqId:orderItemSeqId,shipGroupSeqId:shipGroupSeqId,cancelQuantity:1]"/>
+            <service-call name="co.hotwax.oms.impl.OrderReservationServices.cancel#OrderItemInventoryReservation"
+                          in-map="[orderId:orderId,orderItemSeqId:orderItemSeqId,cancelQuantity:orderItem.quantity]"/>
 
             <!--2. Move to rejected facility-->
             <entity-find-one entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" value-field="currentShipGroup">
                 <field-map field-name="shipGroupSeqId"/>
                 <field-map field-name="orderId" />
             </entity-find-one>
-            <set field="currentShipGroup.facilityId" from="rejectToFacilityId"/>
-            <service-call name="update#org.apache.ofbiz.order.order.OrderItemShipGroup" in-map="currentShipGroup"/>
-
-            <!--3. Call create order facility change-->
-            <set field="orderFacilityChangeMap" from="[:]"/>
-            <set field="orderFacilityChangeMap.orderId" from="orderId"/>
-            <set field="orderFacilityChangeMap.facilityId" from="rejectToFacilityId"/>
-            <set field="orderFacilityChangeMap.fromFacilityId" from="facilityId"/>
-            <set field="orderFacilityChangeMap.shipmentMethodTypeId" value="STANDARD"/>
-            <set field="orderFacilityChangeMap.shipGroupSeqId" from="currentShipGroup.shipGroupSeqId"/>
-            <set field="orderFacilityChangeMap.orderItemSeqId" from="orderItemSeqId"/>
-            <set field="orderFacilityChangeMap.changeReasonEnumId" from="rejectionReasonId"/>
-            <set field="orderFacilityChangeMap.changeUserLogin" from="ec.user.getUsername()?:ec.user.getUserId()"/>
-            <set field="orderFacilityChangeMap.changeDatetime" from="ec.user.nowTimestamp"/>
-            <set field="orderFacilityChangeMap.comments" from="rejectComments"/>
-            <service-call name="create#co.hotwax.facility.OrderFacilityChange" in-map="orderFacilityChangeMap"/>
+            <set field="fromFacilityId" from="currentShipGroup.facilityId"/>
+            <service-call name="co.hotwax.oms.impl.OrderReservationServices.process#OrderItemAllocation"
+                          in-map="[orderId: orderId, orderItemSeqId:orderItemSeqId, facilityId: rejectToFacilityId, quantity: orderItem.quantity]"
+                          out-map="outMap"/>
 
             <!--4. createUpdateExternalFulfillmentOrderItem-->
-            <set field="createUpdateExternalFulfillmentOrderItemMap" from="[:]"/>
-            <set field="createUpdateExternalFulfillmentOrderItemMap.orderId" from="orderId"/>
-            <set field="createUpdateExternalFulfillmentOrderItemMap.orderItemSeqId" from="orderItemSeqId"/>
-            <set field="createUpdateExternalFulfillmentOrderItemMap.shipGroupSeqId" from="currentShipGroup.shipGroupSeqId"/>
-            <set field="createUpdateExternalFulfillmentOrderItemMap.fulfillmentStatus" value="REJECT"/>
-            <service-call name="create#co.hotwax.integration.order.ExternalFulfillmentOrderItem" in-map="createUpdateExternalFulfillmentOrderItemMap"/>
+            <service-call name="store#co.hotwax.integration.order.ExternalFulfillmentOrderItem"
+                          in-map="context + [fulfillmentStatus: 'REJECT']"/>
 
             <!--5. createOrderHistory-->
-            <set field="orderHistoryMap" from="[:]"/>
-            <set field="orderHistoryMap.orderId" from="orderId"/>
-            <set field="orderHistoryMap.orderItemSeqId" from="orderItemSeqId"/>
-            <set field="orderHistoryMap.shipGroupSeqId" from="currentShipGroup.shipGroupSeqId"/>
-            <set field="orderHistoryMap.eventTypeEnumId" from="ITEM_BKD_REJECTED"/>
-            <service-call name="create#co.hotwax.customerservice.order.OrderHistory" in-map="orderHistoryMap"/>
+            <service-call name="create#co.hotwax.customerservice.order.OrderHistory"
+                          in-map="context + [eventTypeEnumId: 'ITEM_BKD_REJECTED']"/>
 
-            <!-- Set the facility and fulfillment status in solr doc -->
+            <!-- TODO: Move this to SECA: Set the facility and fulfillment status in solr doc -->
             <service-call name="co.hotwax.poorti.FulfillmentServices.update#OrderItemFulfillmentStatus"
                           in-map="[orderId:orderId,orderItemSeqId:orderItemSeqId,facilityId:rejectToFacilityId,fulfillmentStatus:'Rejected']"/>
 

--- a/service/co/hotwax/oms/order/OrderServices.xml
+++ b/service/co/hotwax/oms/order/OrderServices.xml
@@ -356,7 +356,6 @@ under the License.
             <parameter name="orderId" required="true"/>
             <parameter name="orderItemSeqId" required="true"/>
             <parameter name="rejectToFacilityId" default-value="REJECTED_ITM_PARKING"/>
-            <parameter name="recordVariance" default-value="Y"/>
             <parameter name="updateQOH" default-value="false" type="Boolean"/>
             <parameter name="rejectionReasonId" required="true"/>
             <parameter name="rejectComments" />
@@ -367,10 +366,14 @@ under the License.
             </parameter>
         </out-parameters>
         <actions>
+            <entity-find-one entity-name="org.apache.ofbiz.product.facility.Facility" value-field="rejectToFacility" cache="true">
+                <field-map field-name="facilityId" from="rejectToFacilityId"/>
+            </entity-find-one>
             <set field="hasParentType"
-                 from="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'org.apache.ofbiz.product.facility.FacilityType', 'facilityTypeId', rejectToFacilityId, 'parentTypeId', 'VIRTUAL_FACILITY')" type="Boolean"/>
+                 from="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'org.apache.ofbiz.product.facility.FacilityType', 'facilityTypeId', rejectToFacility?.facilityTypeId, 'parentTypeId', 'VIRTUAL_FACILITY')" type="Boolean"/>
             <if condition="!hasParentType">
-                <return error="true" message="Order item [${orderId}:${orderItemSeqId} can't be rejected to non virtual facility]"/>
+                <set field="facilityName" from="rejectToFacility != null ? rejectToFacility.facilityName : rejectToFacilityId"/>
+                <return error="true" message="Order item [${orderId}:${orderItemSeqId} can't be rejected to non virtual facility ${facilityName}"/>
             </if>
             <!--Fetch shipGroupSeqId of item before processing anything -->
             <entity-find-one entity-name="org.apache.ofbiz.order.order.OrderItem" value-field="orderItem">
@@ -405,79 +408,45 @@ under the License.
             <!-- TODO: Move this to SECA: Set the facility and fulfillment status in solr doc -->
             <service-call name="co.hotwax.poorti.FulfillmentServices.update#OrderItemFulfillmentStatus"
                           in-map="[orderId:orderId,orderItemSeqId:orderItemSeqId,facilityId:rejectToFacilityId,fulfillmentStatus:'Rejected']"/>
-
             <!--6. Record inventory variance-->
             <entity-find-one entity-name="moqui.basic.Enumeration" value-field="enumMap" cache="true">
                 <field-map field-name="enumId" from="rejectionReasonId"/>
             </entity-find-one>
+            <entity-find-one entity-name="co.hotwax.oms.product.inventory.ProductFacilityInventoryItemView" value-field="productFacility">
+                <field-map field-name="productId" from="orderItem.productId"/>
+                <field-map field-name="facilityId" from="facilityId"/>
+            </entity-find-one>
 
             <set field="enumType" from="enumMap.enumTypeId"/>
             <set field="varianceQuantity" value="0" type="BigDecimal"/>
-
-            <if condition="enumType.equals('REPORT_NO_VAR')">
-                <return message="Item rejected succesfully to facility: $rejectToFacilityId}" type="success"/>
-            </if>
-
-            <if condition="enumType.equals('REPORT_VAR')">
-                <set field="varianceQuantity" value="1" type="BigDecimal"/>
-            </if>
-            <if condition="enumType.equals('REPORT_ALL_VAR')">
-                <entity-find-one entity-name="org.apache.ofbiz.product.facility.ProductFacility" value-field="productFacility">
-                    <field-map field-name="productId" from="orderItem.productId"/>
-                    <field-map field-name="facilityId" from="facilityId"/>
-                </entity-find-one>
-
-                <set field="varianceQuantity" from="productFacility.lastInventoryCount" type="BigDecimal"/>
-            </if>
-
-            <entity-find entity-name="co.hotwax.oms.product.inventory.ProductFacilityInventoryItemView" list="productFacilityInventoryItemViews">
-                <econdition field-name="productId" from="orderItem.productId"/>
-                <econdition field-name="facilityId" from="facilityId"/>
-                <econdition field-name="availableToPromise" operator="greater" value="0"/>
-            </entity-find>
-
-            <set field="productFacilityInventoryItemView" from="productFacilityInventoryItemViews[0]"/>
-            <set field="availableToPromiseVar" type="BigDecimal" from="productFacilityInventoryItemView.availableToPromise"/>
-
-            <if condition="varianceQuantity!=null">
-                <if condition="availableToPromiseVar >= varianceQuantity ">
-                    <then>
-                        <set field="availableToPromiseVar" type="BigDecimal" from="varianceQuantity"/>
-                        <set field="varianceQuantity" type="BigDecimal" value="0"/>
-                    </then>
-                    <else>
-                        <!-- Variance is greater than atp, what to do ?  Second pass ? -->
-                        <set field="varianceQuantity" type="BigDecimal" from="varianceQuantity.subtract(availableToPromiseVar)"/>
-                    </else>
-                </if>
+            <if condition="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'moqui.basic.EnumerationType', 'enumTypeId', 'REPORT_NO_VAR', 'parentTypeId', 'REPORT_NO_VAR')">
+                <return message="Item rejected successfully to facility: $rejectToFacilityId}" type="success"/>
+            <else-if condition="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'moqui.basic.EnumerationType', 'enumTypeId', 'REPORT_NO_VAR', 'parentTypeId', 'REPORT_VAR')">
+                    <set field="varianceQuantity" from="orderItem.quantity" type="BigDecimal"/>
+                <else-if condition="co.hotwax.oms.util.OmsUtil.hasParentType(ec.ecfi , 'moqui.basic.EnumerationType', 'enumTypeId', 'REPORT_NO_VAR', 'parentTypeId', 'REPORT_ALL_VAR')">
+                    <set field="varianceQuantity" from="productFacility.lastInventoryCount" type="BigDecimal"/>
+                </else-if>
+            </else-if>
             </if>
             <!--Run the code to record variance -->
-
+            <if condition="varianceQuantity>0">
             <!-- These details go in a map placed inside 'inventoryItemVariances' list -->
-            <set field="inventoryItemVariances" from="[]"/>
-            <set field="inventoryItemVarianceMap" from="[:]"/>
-            <set field="inventoryItemVarianceMap.inventoryItemId" from="productFacilityInventoryItemView.inventoryItemId"/>
-            <set field="inventoryItemVarianceMap.varianceReasonId" from="rejectionReasonId"/>
-            <set field="inventoryItemVarianceMap.comments" from="rejectComments"/>
-            <set field="inventoryItemVarianceMap.availableToPromiseVar" from="availableToPromiseVar.negate()"/>
+            <set field="inventoryItemVarianceMap"
+                    from="[inventoryItemId: productFacility.inventoryItemId, varianceReasonId: rejectionReasonId,
+                        comments: rejectComments, availableToPromiseVar: varianceQuantity.negative()]"/>
 
             <if condition="updateQOH">
-                <set field="inventoryItemVarianceMap.quantityOnHandVar" from="availableToPromiseVar.negate()"/>
+                <set field="inventoryItemVarianceMap.quantityOnHandVar" from="varianceQuantity.negate()"/>
             </if>
-
-            <script>
-                inventoryItemVariances.add(inventoryItemVarianceMap)
-            </script>
+            <set field="inventoryItemVarianceMap.inventoryItemDetail"
+                    from="[orderId: orderId, orderItemSeqId: orderItemSeqId,shipGroupSeqId:shipGroupSeqId, rejectionReasonId: rejectionReasonId,
+                     availableToPromiseDiff : inventoryItemVarianceMap.availableToPromiseVar,  quantityOnHandDiff : inventoryItemVarianceMap.quantityOnHandVar]"/>
 
             <!--  These go in top level Map - createPhysicalInventoryMap -->
-            <set field="createPhysicalInventoryMap" from="[:]"/>
-            <set field="createPhysicalInventoryMap.physicalInventoryDate" from="ec.user.nowTimestamp" />
-            <set field="createPhysicalInventoryMap.partyId" from="ec.user.getUsername()?:ec.user.getUserId().partyId" />
-            <set field="createPhysicalInventoryMap.inventoryItemVariances" from="inventoryItemVariances" />
-
+            <set field="createPhysicalInventoryMap" from="[partyId:ec.user.getUserAccount()?.partyId, inventoryItemVariances: [inventoryItemVarianceMap]]"/>
             <!--  Call create Physical Inventory -->
             <service-call name="co.hotwax.poorti.FulfillmentServices.create#PhysicalInventory" in-map="createPhysicalInventoryMap" out-map="result"/>
-
+            </if>
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/oms/order/OrderServices.xml
+++ b/service/co/hotwax/oms/order/OrderServices.xml
@@ -329,8 +329,15 @@ under the License.
             <parameter name="rejectComments" />
         </in-parameters>
         <out-parameters>
-            <parameter name="cancelledReservations" type="Map">
-
+            <!-- Returning a list, as in the case of a marketing package, we also perform reservation for its components.-->
+            <parameter name="cancelledReservations" type="List">
+                <parameter name="cancelledReservation">
+                    <parameter name="orderId"/>
+                    <parameter name="orderItemSeqId"/>
+                    <parameter name="shipGroupSeqId"/>
+                    <parameter name="inventoryItemId"/>
+                    <parameter name="cancelledQuantity" type="BigDecimal"/>
+                </parameter>
             </parameter>
         </out-parameters>
         <actions>
@@ -353,8 +360,9 @@ under the License.
 
             <!--1. Cancel Inventory Reservation call cancel#OrderItemShipGrpInvRes -->
             <service-call name="co.hotwax.oms.impl.OrderReservationServices.cancel#OrderItemInventoryReservation"
-                          in-map="[orderId:orderId,orderItemSeqId:orderItemSeqId,cancelQuantity:orderItem.quantity]"/>
+                          in-map="[orderId:orderId,orderItemSeqId:orderItemSeqId,cancelQuantity:orderItem.quantity]" out-map="outResult"/>
 
+            <set field="cancelledReservations" from="outResult.cancelledReservations"/>
             <!--2. Move to rejected facility-->
             <entity-find-one entity-name="org.apache.ofbiz.order.order.OrderItemShipGroup" value-field="currentShipGroup">
                 <field-map field-name="shipGroupSeqId"/>

--- a/service/co/hotwax/orderledger/order/OrderServices.xml
+++ b/service/co/hotwax/orderledger/order/OrderServices.xml
@@ -71,9 +71,9 @@ under the License.
             <service-call name="create#org.apache.ofbiz.order.order.OrderHeaderNote" in-map="[orderId:orderId, noteId:noteDataResponse.noteId]"/>
             <!-- TODO: internalNote:Y or N ; Also we can save the comment/reason as a part of the note-->
 
-            <!-- Call cancel#OrderItemInvResQty to cancel the inventory reservation -->
-            <service-call name="co.hotwax.oms.order.OrderServices.cancel#OrderItemInvResQty" in-map="[orderId:orderId, orderItemSeqId:orderItemSeqId,
-                    shipGroupSeqId:shipGroupSeqId]"/>
+            <!-- Call cancel#OrderItemInventoryReservation to cancel the inventory reservation -->
+            <service-call name="co.hotwax.oms.impl.OrderReservationServices.cancel#OrderItemInventoryReservation" in-map="[orderId:orderId, orderItemSeqId:orderItemSeqId,
+                    cancelQuantity:orderItem.quantity]"/>
 
             <!-- Call get#OrderItemSalesTaxTotal inline and get the sales tax total of the order item -->
             <service-call name="co.hotwax.oms.order.OrderServices.get#OrderItemSalesTaxTotal" in-map="[orderId:orderId, orderItemSeqId:orderItemSeqId]" out-map="orderItemSalesTaxTotalResponse"/>


### PR DESCRIPTION
Implemented the rejectOrderItem service and refactored related logic to maintain clean component boundaries.

Removed shipment rejection logic from OMS; this responsibility belongs to the Fulfillment application to avoid component dependency violations.

**Cancel inventory reservations**
- Used cancel#OrderItemInventoryReservation to cancel item and package component reservations.

**Move item to rejection facility**
- Utilized process#OrderItemAllocation to reassign the item to rejectToFacilityId.

**Update external fulfillment records**
- Created or updated the ExternalFulfillmentOrderItem entity.

**Track order history**
- Added an OrderHistory record with relevant rejection details.

**Create inventory variance via create#PhysicalInventory, based on the rejectionReasonId's enumeration type:**


- If parent type is REPORT_NO_VAR → No variance is logged
- If parent type is REPORT_VAR → Log variance for rejected quantity
- If parent type is REPORT_ALL_VAR → Log variance for the full quantity of the product at the facility