### PR TITLE
Backport product indexing for virtual product only to v1.1.1

### DIFF
--- a/service/co/hotwax/oms/product/ProductServices.xml
+++ b/service/co/hotwax/oms/product/ProductServices.xml
@@ -73,22 +73,14 @@ under the License.
                 </if>
             </if>
 
+            <service-call name="co.hotwax.oms.search.SearchServices.call#CreateProductIndex" in-map="[productId:parentProductId, indexVariants:true]" ignore-error="true"/>
+            <log level="info" message="Created product index for oms productId : ${parentProductId}"/>
+
             <if condition="variantErrors">
                 <script>
                     ec.message.addError(variantErrors.toString())
                 </script>
             </if>
-
-            <service-call name="co.hotwax.oms.search.SearchServices.call#CreateProductIndex" in-map="[productId:parentProductId]"
-                          transaction="force-new" ignore-error="true"/>
-            <log level="info" message="Created product index for oms productId : ${parentProductId}"/>
-            <if condition="variantProductIds">
-                <iterate list="variantProductIds" entry="variantProductId">
-                     <service-call name="co.hotwax.oms.search.SearchServices.call#CreateProductIndex" in-map="[productId:variantProductId]"
-                                   transaction="force-new" ignore-error="true"/>
-                    <log level="info" message="Created product index for oms productId : ${variantProductId}"/>
-                </iterate>
-             </if>
         </actions>
     </service>
 
@@ -351,22 +343,14 @@ under the License.
                 </if>
             </if>
 
+            <service-call name="co.hotwax.oms.search.SearchServices.call#CreateProductIndex" in-map="[productId:parentProductId, indexVariants:true]" ignore-error="true"/>
+            <log level="info" message="Created product index for oms productId : ${parentProductId}"/>
+
             <if condition="variantErrors">
                 <script>
                     ec.message.addError(variantErrors.toString())
                 </script>
             </if>
-
-            <service-call name="co.hotwax.oms.search.SearchServices.call#CreateProductIndex" in-map="[productId:parentProductId]"
-                          transaction="force-new" ignore-error="true"/>
-                <log level="info" message="Created product index for oms productId : ${parentProductId}"/>
-                <if condition="variantProductIds">
-                    <iterate list="variantProductIds" entry="variantProductId">
-                        <service-call name="co.hotwax.oms.search.SearchServices.call#CreateProductIndex" in-map="[productId:variantProductId]"
-                                      transaction="force-new" ignore-error="true"/>
-                        <log level="info" message="Created product index for oms productId : ${variantProductId}"/>
-                    </iterate>
-                </if>
         </actions>
     </service>
 

--- a/service/co/hotwax/oms/search/SearchServices.xml
+++ b/service/co/hotwax/oms/search/SearchServices.xml
@@ -29,7 +29,8 @@ under the License.
     <service verb="call" noun="CreateProductIndex" type="oms-rest" location="service/createProductIndex" method="post" authenticate="false">
         <description>Call OMS CreateProductIndex service.</description>
         <in-parameters>
-            <parameter name="productId"/>
+            <parameter name="productId" required="true"/>
+            <parameter name="indexVariants" default-value="false"/>
         </in-parameters>
         <out-parameters>
             <parameter name="response" type="Map"/>


### PR DESCRIPTION
1. Index virtual products only with indexVariant=true to reduce number of API calls to OMS.