### PR TITLE
Update create IID service to Populate the last ATP and last QOH fields

### DIFF
--- a/component.xml
+++ b/component.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/moqui-conf-3.xsd"
-           name="oms" version="1.2.0">
+           name="oms" version="1.3.0">
     <!-- no dependencies -->
 </component>

--- a/service/co/hotwax/oms/product/InventoryServices.xml
+++ b/service/co/hotwax/oms/product/InventoryServices.xml
@@ -35,6 +35,12 @@ under the License.
 
             <set field="itemDetailED" from="ec.entity.getEntityDefinition('org.apache.ofbiz.product.inventory.InventoryItemDetail')"/>
             <set field="newEntity.inventoryItemDetailSeqId" from="ec.entityFacade.sequencedIdPrimaryEd(itemDetailED)"/>
+            <set field="inventoryItemDetailSeqId" from="newEntity.inventoryItemDetailSeqId"/>
+
+            <entity-find-one entity-name="co.hotwax.oms.product.inventory.InventoryItemDetailSummary" value-field="inventoryItemDetailSummary"/>
+            <set field="newEntity.lastQuantityOnHand" from="inventoryItemDetailSummary.quantityOnHandTotal"/>
+            <set field="newEntity.lastAvailableToPromise" from="inventoryItemDetailSummary.availableToPromiseTotal"/>
+
             <if condition="!newEntity.availableToPromiseDiff">
                 <set field="newEntity.availableToPromiseDiff" value="0" type="BigDecimal"/>
             </if>


### PR DESCRIPTION
### Changes:
- Fixed bug: Earlier service not put the `inventoryItemDetailSeqId` field
- Add Logic to fetch the values of total ATP and QOH, and then update into the detail record