### PR TITLE
Improved: Added default values for lastQuantityOnHand and lastAvailableToPromise for new Inventory Item scenario

### DIFF
--- a/service/co/hotwax/oms/product/InventoryServices.xml
+++ b/service/co/hotwax/oms/product/InventoryServices.xml
@@ -38,8 +38,8 @@ under the License.
             <set field="inventoryItemDetailSeqId" from="newEntity.inventoryItemDetailSeqId"/>
 
             <entity-find-one entity-name="co.hotwax.oms.product.inventory.InventoryItemDetailSummary" value-field="inventoryItemDetailSummary"/>
-            <set field="newEntity.lastQuantityOnHand" from="inventoryItemDetailSummary.quantityOnHandTotal"/>
-            <set field="newEntity.lastAvailableToPromise" from="inventoryItemDetailSummary.availableToPromiseTotal"/>
+            <set field="newEntity.lastQuantityOnHand" from="inventoryItemDetailSummary?.quantityOnHandTotal" default-value="0"/>
+            <set field="newEntity.lastAvailableToPromise" from="inventoryItemDetailSummary?.availableToPromiseTotal" default-value="0"/>
 
             <if condition="!newEntity.availableToPromiseDiff">
                 <set field="newEntity.availableToPromiseDiff" value="0" type="BigDecimal"/>


### PR DESCRIPTION
1. Faced issue when testing for the scenario of receiving new product in the transfer order.
2. Added default-value=0 for lastQuantityOnHand and lastAvailableToPromise if no InventoryItem found
3. This fixes the possible NPE