### PR TITLE
Update payload for calling createPhysicalInventory service

### DIFF
--- a/service/co/hotwax/oms/order/OrderServices.xml
+++ b/service/co/hotwax/oms/order/OrderServices.xml
@@ -476,7 +476,7 @@ under the License.
                         <set field="inventoryItemVarianceMap.quantityOnHandVar" from="varianceQuantity.negate()"/>
                     </if>
                     <set field="inventoryItemVarianceMap.inventoryItemDetail"
-                         from="[rejectionReasonId: rejectionReasonId,
+                         from="[orderId: orderId, orderItemSeqId: orderItemSeqId, rejectionReasonId: rejectionReasonId,
                      availableToPromiseDiff : inventoryItemVarianceMap.availableToPromiseVar,  quantityOnHandDiff : inventoryItemVarianceMap.quantityOnHandVar]"/>
 
                     <!--  These go in top level Map - createPhysicalInventoryMap -->


### PR DESCRIPTION
Related Issue: https://git.hotwax.co/commerce/poorti/-/issues/59

Update the input map for calling the `create#PhysicalInventory` service,  to include the `orderId`, `orderItemSeqId` parameter values, and store in the detail record.