### PR TITLE
Improved: Added Status Transitions for Item Cancel scenario for Transfer Order

### DIFF
--- a/data/TransferOrderSeedData.xml
+++ b/data/TransferOrderSeedData.xml
@@ -8,7 +8,8 @@
     <!-- Status Flow for Transfer Orders to be fulfilled only in OMS -->
     <moqui.basic.StatusFlow statusFlowId="TO_Fulfill_Only" statusTypeId="ORDER_ITEM_STATUS" description="Status Flow for Transfer Orders to be fulfilled in OMS and receiving by third party e.g. Store to Warehouse"/>
     <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_Only" statusId="ITEM_CREATED" toStatusId="ITEM_PENDING_FULFILL" transitionSequence="1" transitionName="Approve Item"/>
-    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_Only" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_COMPLETED" transitionSequence="1" transitionName="Fulfill Item" conditionExpression="isItemPendingFulfill == false"/>
+    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_Only" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_COMPLETED" transitionSequence="1" transitionName="Fulfill Item" conditionExpression="isItemPendingFulfill == false &amp;&amp; totalIssuedQuantity &gt; 0"/>
+    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_Only" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_CANCELLED" transitionSequence="2" transitionName="Cancel Item" conditionExpression="isItemPendingFulfill == false &amp;&amp; totalIssuedQuantity == 0"/>
 
     <!-- Status Flow for Transfer Orders to be only received in OMS -->
     <moqui.basic.StatusFlow statusFlowId="TO_Receive_Only" statusTypeId="ORDER_ITEM_STATUS" description="Status Flow for Transfer Orders fulfilled by third party and receiving in OMS e.g. Warehouse to Store"/>
@@ -18,6 +19,7 @@
     <!-- Status Flow for Transfer Orders to be both fulfilled and received in OMS -->
     <moqui.basic.StatusFlow statusFlowId="TO_Fulfill_And_Receive" statusTypeId="ORDER_ITEM_STATUS" description="Status Flow for Orders to be both fulfilled and received in OMS e.g. Store to Store"/>
     <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_And_Receive" statusId="ITEM_CREATED" toStatusId="ITEM_PENDING_FULFILL" transitionSequence="1" transitionName="Approve Item"/>
-    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_And_Receive" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_PENDING_RECEIPT" transitionSequence="1" transitionName="Fulfill Item" conditionExpression="isItemPendingFulfill == false"/>
+    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_And_Receive" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_PENDING_RECEIPT" transitionSequence="1" transitionName="Fulfill Item" conditionExpression="isItemPendingFulfill == false &amp;&amp; totalIssuedQuantity &gt; 0"/>
+    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_And_Receive" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_CANCELLED" transitionSequence="2" transitionName="Cancel Item" conditionExpression="isItemPendingFulfill == false &amp;&amp; totalIssuedQuantity == 0"/>
     <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_And_Receive" statusId="ITEM_PENDING_RECEIPT" toStatusId="ITEM_COMPLETED" transitionSequence="1" transitionName="Receive Item" conditionExpression="isItemPendingReceipt == false"/>
 </entity-facade-xml>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -7,7 +7,8 @@
     <!-- Status Flow for Transfer Orders to be fulfilled only in OMS -->
     <moqui.basic.StatusFlow statusFlowId="TO_Fulfill_Only" statusTypeId="ORDER_ITEM_STATUS" description="Status Flow for Transfer Orders to be fulfilled in OMS and receiving by third party e.g. Store to Warehouse"/>
     <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_Only" statusId="ITEM_CREATED" toStatusId="ITEM_PENDING_FULFILL" transitionSequence="1" transitionName="Approve Item"/>
-    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_Only" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_COMPLETED" transitionSequence="1" transitionName="Fulfill Item" conditionExpression="isItemPendingFulfill == false"/>
+    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_Only" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_COMPLETED" transitionSequence="1" transitionName="Fulfill Item" conditionExpression="isItemPendingFulfill == false &amp;&amp; totalIssuedQuantity &gt; 0"/>
+    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_Only" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_CANCELLED" transitionSequence="2" transitionName="Cancel Item" conditionExpression="isItemPendingFulfill == false &amp;&amp; totalIssuedQuantity == 0"/>
 
     <!-- Status Flow for Transfer Orders to be only received in OMS -->
     <moqui.basic.StatusFlow statusFlowId="TO_Receive_Only" statusTypeId="ORDER_ITEM_STATUS" description="Status Flow for Transfer Orders fulfilled by third party and receiving in OMS e.g. Warehouse to Store"/>
@@ -17,7 +18,8 @@
     <!-- Status Flow for Transfer Orders to be both fulfilled and received in OMS -->
     <moqui.basic.StatusFlow statusFlowId="TO_Fulfill_And_Receive" statusTypeId="ORDER_ITEM_STATUS" description="Status Flow for Orders to be both fulfilled and received in OMS e.g. Store to Store"/>
     <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_And_Receive" statusId="ITEM_CREATED" toStatusId="ITEM_PENDING_FULFILL" transitionSequence="1" transitionName="Approve Item"/>
-    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_And_Receive" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_PENDING_RECEIPT" transitionSequence="1" transitionName="Fulfill Item" conditionExpression="isItemPendingFulfill == false"/>
+    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_And_Receive" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_PENDING_RECEIPT" transitionSequence="1" transitionName="Fulfill Item" conditionExpression="isItemPendingFulfill == false &amp;&amp; totalIssuedQuantity &gt; 0"/>
+    <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_And_Receive" statusId="ITEM_PENDING_FULFILL" toStatusId="ITEM_CANCELLED" transitionSequence="2" transitionName="Cancel Item" conditionExpression="isItemPendingFulfill == false &amp;&amp; totalIssuedQuantity == 0"/>
     <moqui.basic.StatusFlowTransition statusFlowId="TO_Fulfill_And_Receive" statusId="ITEM_PENDING_RECEIPT" toStatusId="ITEM_COMPLETED" transitionSequence="1" transitionName="Receive Item" conditionExpression="isItemPendingReceipt == false"/>
 
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSTransferOrderFeed"


### PR DESCRIPTION
1. Included status transition for ITEM_CANCELLED.
2. This is the scenario where Transfer Order Items can be closed for Fulfillment with 0 qty shipped.

Closes #201 