### PR TITLE
Improved: Get Transfer Order detail API to include maySplit field

### DIFF
--- a/service/co/hotwax/orderledger/order/TransferOrderServices.xml
+++ b/service/co/hotwax/orderledger/order/TransferOrderServices.xml
@@ -74,6 +74,7 @@
                 <parameter name="orderName"/>
                 <parameter name="externalId"/>
                 <parameter name="statusId"/>
+                <parameter name="maySplit"/>
                 <parameter name="items" type="List">
                     <parameter name="orderItemMap" type="Map">
                         <parameter name="orderItemSeqId"/>
@@ -84,6 +85,7 @@
                         <parameter name="itemDescription"/>
                         <parameter name="cancelQuantity"/>
                         <parameter name="productId"/>
+                        <parameter name="maySplit"/>
                         <parameter name="totalIssuedQuantity"/>
                         <parameter name="totalReceivedQuantity"/>
                     </parameter>
@@ -103,15 +105,17 @@
             <set field="order.status" from="statusItem?.description"/>
 
             <!-- Get Order Item details -->
-            <entity-find entity-name="org.apache.ofbiz.order.order.OrderItem" list="orderItemList">
-                <econdition field-name="orderId"/>
-                <select-field field-name="orderItemSeqId,shipGroupSeqId,productId,quantity,statusId,itemDescription,cancelQuantity"/>
+            <entity-find entity-name="co.hotwax.order.OrderItemAndShipGroup" list="orderItemList">
+                <econdition field-name="orderId" from="orderId"/>
+                <select-field field-name="orderItemSeqId,shipGroupSeqId,productId,quantity,statusId,itemDescription,cancelQuantity,maySplit,facilityId"/>
             </entity-find>
+            <set field="order.maySplit" from="orderItemList?.first?.maySplit"/>
 
             <set field="order.items" from="[]"/>
-
             <iterate list="orderItemList" entry="orderItem">
-                <entity-find-related-one value-field="orderItem" relationship-name="moqui.basic.StatusItem" to-value-field="statusItem" cache="true"/>
+                <entity-find-one entity-name="moqui.basic.StatusItem" value-field="statusItem" cache="true">
+                    <field-map field-name="statusId" from="orderItem.statusId"/>
+                </entity-find-one>
 
                 <set field="orderItem" from="orderItem.getPlainValueMap(0)"/>
 


### PR DESCRIPTION
1. This is required to support the cancellation or rejection of the TO.
2. Based on the field maySplit in the GET TO Details API, the TO can be rejected or cancelled.
3. The Transfer Orders can be created for below scenarios
    1. When TO is created to fulfill a demand of Sales Order and is Store to Store type transfer.
        1. Here, the maySplit should be set to N.
        2. In this case, the TO can either be Rejected as a whole or it can be fulfilled as a whole.
        3. No Partial shipment allowed.
    2. When excess inventory is being returned to Warehouse after season, so these will be store to wh type transfers
        1. Here, the maySplit should be set to Y (empty will also be considered as Y)
        2. In this case, the TO cannot be Rejected, it can be Canceled which is done by "Close Items" option.
        3. The TO can be shipped in multiple shipments.
4. Based on the maySplit field from the API, the Fulfillment UI will enable the options to Reject or Cancel orders and/or other actions for the TO.

Closes #205 