### PR TITLE
Improved: Added excludeOriginFacilityIds parameter in get Transfer Orders API

### DIFF
--- a/service/co/hotwax/orderledger/order/TransferOrderServices.xml
+++ b/service/co/hotwax/orderledger/order/TransferOrderServices.xml
@@ -20,10 +20,15 @@
                 <description>The ID of the status of the Transfer Order Item in OMS.</description>
             </parameter>
             <parameter name="originFacilityId">
-                <description>The ID of the origin facility of the Transfer Order in OMS.</description>
+                <description>The ID of the source facility of the Transfer Order in OMS.</description>
             </parameter>
             <parameter name="destinationFacilityId">
                 <description>The ID of the destination facility of the Transfer Order in OMS.</description>
+            </parameter>
+            <parameter name="excludeOriginFacilityIds" type="List">
+                <description>
+                    The list of source Facility IDs OMS to exclude.
+                    Eg. To exclude the Rejected TOs in the Receiving App, send the parameter with value as REJECTED_ITM_PARKING.</description>
             </parameter>
             <parameter name="orderName">
                 <description>The order name of Transfer Order.</description>
@@ -58,6 +63,7 @@
                 <econdition field-name="orderId" ignore-if-empty="true"/>
                 <econdition field-name="orderStatusId"/>
                 <econdition field-name="itemStatusId" ignore-if-empty="true"/>
+                <econdition field-name="facilityId" from="excludeOriginFacilityIds" ignore-if-empty="true" operator="not-in"/>
                 <econdition field-name="facilityId" from="originFacilityId" ignore-if-empty="true"/>
                 <econdition field-name="orderFacilityId" from="destinationFacilityId" ignore-if-empty="true"/>
                 <econdition field-name="orderName" operator="like" value="%${orderName}%" ignore="!orderName"/>

--- a/service/co/hotwax/orderledger/order/TransferOrderServices.xml
+++ b/service/co/hotwax/orderledger/order/TransferOrderServices.xml
@@ -27,7 +27,7 @@
             </parameter>
             <parameter name="excludeOriginFacilityIds" type="List">
                 <description>
-                    The list of source Facility IDs OMS to exclude.
+                    The list of source Facility IDs in OMS to exclude for the Transfer Orders.
                     Eg. To exclude the Rejected TOs in the Receiving App, send the parameter with value as REJECTED_ITM_PARKING.</description>
             </parameter>
             <parameter name="orderName">


### PR DESCRIPTION

This is done to add the support to exlude the Rejected TOs in the Receiving App i.e. TOs where facility ID = REJECTED_ITM_PARKING

Closes #233 