### PR TITLE
BugFix: Updated sending enumId instead of map object

### DIFF
--- a/service/co/hotwax/orderledger/order/OrderServices.xml
+++ b/service/co/hotwax/orderledger/order/OrderServices.xml
@@ -105,7 +105,7 @@ under the License.
             </if>
 
             <!-- Call reject#OrderItem service to release the reservations and reset the Shipment -->
-            <set field="rejectionReasonId" from="reasonEnum.enumerationId"/>
+            <set field="rejectionReasonId" from="reasonEnum.enumId"/>
             <service-call name="co.hotwax.oms.order.OrderServices.reject#OrderItem"
                           in-map="context" out-map="outResult"/>
             <set field="cancelledItems" from="outResult.cancelledReservations"/>

--- a/service/co/hotwax/orderledger/order/OrderServices.xml
+++ b/service/co/hotwax/orderledger/order/OrderServices.xml
@@ -105,7 +105,7 @@ under the License.
             </if>
 
             <!-- Call reject#OrderItem service to release the reservations and reset the Shipment -->
-            <set field="rejectionReasonId" from="reasonEnum"/>
+            <set field="rejectionReasonId" from="reasonEnum.enumerationId"/>
             <service-call name="co.hotwax.oms.order.OrderServices.reject#OrderItem"
                           in-map="context" out-map="outResult"/>
             <set field="cancelledItems" from="outResult.cancelledReservations"/>


### PR DESCRIPTION
- Getting the following error when cancelling otder item(s) from Maarg `cancel#SalesOrderItem(s)` service. Sent the `enumId` instead of map's object.
`
"errors" : "Error creating OrderFacilityChange [orderFacilityChangeId:M101534]: text value too long [22001]\nData truncation: Data too long for column 'CHANGE_REASON_ENUM_ID' at row 1\nCannot enlist: no transaction manager or transaction not active\n"
`