### PR TITLE
BugFix: Issue in ignore-if-empty attribute if the variable is not in context

### DIFF
--- a/service/co/hotwax/oms/order/OrderNotificationServices.xml
+++ b/service/co/hotwax/oms/order/OrderNotificationServices.xml
@@ -40,7 +40,7 @@ under the License.
                         <service-call name="co.hotwax.oms.order.OrderNotificationServices.build#TopicName" in-map="[facilityId: shipGroup.facilityId, topicEnumId: topicEnumId]" out-map="context"/>
                         <script>
                             ec.makeNotificationMessage().topic(topicName).type("info").title(enumeration.enumName)
-                            .message([body: "New order: "+ orderId +" received in " + facility.facilityName + "."]).send()
+                            .message([body: "New order received in " + facility.facilityName + "."]).send()
                         </script>
                     </iterate>
                 </if>
@@ -53,7 +53,7 @@ under the License.
         </in-parameters>
         <actions>
             <entity-find entity-name="org.apache.ofbiz.product.facility.Facility" list="facilities" cache="true">
-                <econdition field-name="parentFacilityTypeId" operator="in" value="RETAIL_STORE,WAREHOUSE"/>
+                <econdition field-name="facilityTypeId" operator="in" value="RETAIL_STORE,WAREHOUSE"/>
             </entity-find>
             <entity-find-one entity-name="moqui.basic.Enumeration" value-field="enumeration" cache="true">
                 <field-map field-name="enumId" from="topicEnumId"/>
@@ -63,7 +63,7 @@ under the License.
                     <!-- Send open orders notification for BOPIS orders
                     The get#PickupOrders service returns open BOPIS orders default hence, not passing any in-parameters.
                     -->
-                    <service-call name="co.hotwax.orderledger.order.OrderServices.get#PickupOrders" in-map="[facilityId: facility.facilityId]" out-map="result"/>
+                    <service-call name="co.hotwax.orderledger.order.OrderServices.get#PickupOrders" in-map="[facilityId: facility.facilityId, pageSize: 1]" out-map="result" transaction-timeout="1800"/>
                     <if condition="result.ordersCount == 1">
                         <set field="body" value="One order is open in  ${facility.facilityName}, start preparing for pickup."/>
                         <else>
@@ -74,7 +74,7 @@ under the License.
                         <!-- Send ready for pickup notification for BOPIS orders i.e. Packed orders
                         The get#Shipments service returns total count of shipments
                         -->
-                        <service-call name="co.hotwax.poorti.FulfillmentServices.get#Shipments" in-map="[orderStatusId: 'ORDER_APPROVED', originFacilityId: facility.facilityId, statusId: 'SHIPMENT_PACKED', shipmentMethodTypeIds: 'STOREPICKUP']"
+                        <service-call name="co.hotwax.poorti.FulfillmentServices.get#Shipments" in-map="[orderStatusId: 'ORDER_APPROVED', originFacilityId: facility.facilityId, statusId: 'SHIPMENT_PACKED', shipmentMethodTypeIds: 'STOREPICKUP', pageSize: 1]" transaction-timeout="1800"
                                       out-map="result"/>
                         <if condition="result.shipmentCount == 1">
                             <set field="body" value="One order is ready for pickup at ${facility.facilityName}, resend email notification."/>
@@ -83,7 +83,7 @@ under the License.
                             </else>
                         </if>
                     </else-if><else-if condition="topicEnumId == 'OPEN_SHIPPING_ODR'">
-                    <service-call name="co.hotwax.orderledger.order.OrderServices.get#PickupOrders" in-map="[shipmentMethodTypeId: 'STOREPICKUP', shipmentMethodTypeId_op: 'equals', shipmentMethodTypeId_not: 'Y', facilityId: facility.facilityId]"
+                    <service-call name="co.hotwax.orderledger.order.OrderServices.get#PickupOrders" in-map="[shipmentMethodTypeId: 'STOREPICKUP', shipmentMethodTypeId_op: 'equals', shipmentMethodTypeId_not: 'Y', facilityId: facility.facilityId, pageSize: 1]" transaction-timeout="1800"
                                   out-map="result"/>
                     <if condition="result.ordersCount == 1">
                         <set field="body" value="One order is open in ${facility.facilityName}, start preparing for picking."/>

--- a/service/co/hotwax/orderledger/order/OrderServices.xml
+++ b/service/co/hotwax/orderledger/order/OrderServices.xml
@@ -202,8 +202,8 @@ under the License.
                 <econdition field-name="orderStatusId"/>
                 <econditions combine="or">
                     <econdition field-name="orderId" from="orderId" ignore-if-empty="true"/>
-                    <econdition field-name="orderId" operator="like" value="%${keyword}%" ignore-if-empty="true"/>
-                    <econdition field-name="orderName" operator="like" value="%${keyword}%" ignore-if-empty="true"/>
+                    <econdition field-name="orderId" operator="like" value="%${keyword}%" ignore="keyword == null || keywrod == ''"/>
+                    <econdition field-name="orderName" operator="like" value="%${keyword}%" ignore="keyword == null || keyword == ''"/>
                 </econditions>
                 <econdition field-name="orderId" ignore-if-empty="true"/>
                 <select-field field-name="orderId,orderName,orderExternalId,orderStatusId,orderStatusDesc,orderDate,facilityId"/>


### PR DESCRIPTION
1. Addressed an issue where the keyword variable was being set to null if not passed, leading to incorrect behavior with the LIKE operator, which resulted in the string `%null%` instead of properly skipping the condition.
2. Corrected the validation for the `facilityTypeId` attribute, ensuring it checks against the correct value `facilityTypeId` instead of the `parentFacilityTypeId`.